### PR TITLE
fix login feature for codeforces

### DIFF
--- a/onlinejudge/codeforces.py
+++ b/onlinejudge/codeforces.py
@@ -28,7 +28,7 @@ class CodeforcesService(onlinejudge.service.Service):
         log.debug('form: %s', str(form))
         username, password = get_credentials()
         form = utils.FormSender(form, url=resp.url)
-        form.set('handle', username)
+        form.set('handleOrEmail', username)
         form.set('password', password)
         form.set('remember', 'on')
         # post


### PR DESCRIPTION
codeforcesへログインできなかったので修正しました。
現在のログインページではusernameを格納するパラメータ名が変更されているようです。