### PR TITLE
feature: select submit language by name

### DIFF
--- a/onlinejudge/implementation/command/submit.py
+++ b/onlinejudge/implementation/command/submit.py
@@ -37,12 +37,24 @@ def submit(args):
     with utils.with_cookiejar(utils.new_default_session(), path=args.cookie) as sess:
         # language
         langs = problem.get_language_dict(session=sess)
+
         if args.language not in langs:
-            log.error('language is unknown')
-            log.info('supported languages are:')
-            for lang in sorted(langs.keys()):
-                log.emit('%s (%s)', lang, langs[lang]['description'])
-            sys.exit(1)
+            matched_language = search_matched_language(args.language, langs)
+            if len(matched_language) == 1:
+                args.language = matched_language[0]
+                log.info('choosed language: %s', matched_language)
+            elif not matched_language:
+                log.error('language is unknown')
+                log.info('supported languages are:')
+                for lang in sorted(langs.keys()):
+                    log.emit('%s (%s)', lang, langs[lang]['description'])
+                sys.exit(1)
+            else:
+                log.error('Matched languages were not narrowed down to one.')
+                log.info('You have to choose:')
+                for lang in sorted(matched_language):
+                    log.emit('%s', lang)
+                sys.exit(1)
 
         # confirm
         if args.wait:
@@ -75,3 +87,12 @@ def submit(args):
                 else:
                     log.info('open the submission page with: %s', args.open)
                     subprocess.check_call([ args.open, submission.get_url() ], stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
+
+def search_matched_language(language, language_dict):
+    # Search partial matched language name (not case sensitive)
+
+    matched_language = []
+    for supported_lang in language_dict.values():
+        if language.lower() in supported_lang['description'].lower():
+            matched_language.append(supported_lang['description'])
+    return matched_language


### PR DESCRIPTION
概要
==
submit時、IDの代わりに文字列で入力したいです(毎回テーブル調べるのが面倒なため)

入力例
==
正常時
```
oj s -l rust ...
[*] choosed language: ['Rust (1.15.1)']
```
Rust (1.15.1)を選択したものとして、処理を続行します。

異常時１
```
oj s -l python ...
[ERROR] Matched languages were not narrowed down to one.
[*] You have to choose:
Python2 (2.7.6)
Python3 (3.4.3)
```
Python2 (2.7.6)かPython3 (3.4.3)か絞れないので、どっちか選んでねとメッセージ出して処理をストップします。

異常時2
```
-l aaaa
[ERROR] language is unknown
[*] supported languages are:
3001 (Bash (GNU bash v4.3.11))
3002 (C (GCC 5.4.1))
...
```
そんなものはないぞ、ということで従来通りのエラーメッセージを出します。

どうでしょうか？