### PR TITLE
fix download sample cases from judge.u-aizu.ac.jp

### DIFF
--- a/onlinejudge/aoj.py
+++ b/onlinejudge/aoj.py
@@ -50,7 +50,7 @@ class AOJProblem(onlinejudge.problem.Problem):
         # get
         resp = utils.request('GET', self.get_url(), session=session)
         # parse
-        soup = bs4.BeautifulSoup(resp.content.decode(resp.encoding), utils.html_parser)
+        soup = bs4.BeautifulSoup(resp.content.decode(resp.encoding), 'html.parser')
         samples = utils.SampleZipper()
         for pre in soup.find_all('pre'):
             log.debug('pre: %s', str(pre))


### PR DESCRIPTION
### 概要
AOJからのサンプルケースの取得が動作していなかったのを修正しました。

### 修正内容
AOJのhtmlパース時のパーサーの指定を`lxml`から`html.parser`に変更しました。

### 補足
#### サンプルケースの取得が動作しなかった環境
- macOS 10.13.6
- Python 3.7.0
```
$ python3 -V
Python 3.7.0

$ pip3 -V
pip 18.0 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)

$ pip3 show online-judge-tools lxml beautifulsoup4
Name: online-judge-tools
Version: 0.1.39
Summary: Tools for online-judge services
Home-page: https://github.com/kmyk/online-judge-tools
Author: Kimiyuki Onaka
Author-email: kimiyuki95@gmail.com
License: MIT License
Location: /usr/local/lib/python3.7/site-packages
Requires: requests, sympy, lxml, colorama, beautifulsoup4
Required-by:
---
Name: lxml
Version: 4.2.5
Summary: Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.
Home-page: http://lxml.de/
Author: lxml dev team
Author-email: lxml-dev@lxml.de
License: BSD
Location: /usr/local/lib/python3.7/site-packages
Requires:
Required-by: online-judge-tools
---
Name: beautifulsoup4
Version: 4.6.3
Summary: Screen-scraping library
Home-page: http://www.crummy.com/software/BeautifulSoup/bs4/
Author: Leonard Richardson
Author-email: leonardr@segfault.org
License: MIT
Location: /usr/local/lib/python3.7/site-packages
Requires:
Required-by: online-judge-tools

$ brew info python
python: stable 3.7.0 (bottled), HEAD
Interpreted, interactive, object-oriented programming language
https://www.python.org/
/usr/local/Cellar/python/3.7.0 (4,860 files, 103.2MB) *
  Poured from bottle on 2018-07-26 at 00:20:35
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/python.rb
```
