### PR TITLE
[WIP] oj testでディレクトリ指定できないバグ修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
     only:
         - master
         - develop
-        - "/^v\\d\\.\\d\\.\\d$/"
+        - "/^v\\d+\\.\\d+\\.\\d+$/"
 deploy:
     provider: pypi
     user: kimiyuki

--- a/onlinejudge/implementation/command/generate_output.py
+++ b/onlinejudge/implementation/command/generate_output.py
@@ -13,7 +13,7 @@ def generate_output(args: 'argparse.Namespace') -> None:
         args.test = cutils.glob_with_format(args.directory, args.format) # by default
     if args.ignore_backup:
         args.test = cutils.drop_backup_or_hidden_files(args.test)
-    tests = cutils.construct_relationship_of_files(args.test, args.directory, args.format)
+    tests = cutils.construct_relationship_of_files(args.test, args.format)
     for name, it in sorted(tests.items()):
         log.emit('')
         log.info('%s', name)
@@ -31,7 +31,7 @@ def generate_output(args: 'argparse.Namespace') -> None:
             log.info('skipped.')
             continue
         log.emit(log.bold(answer.decode().rstrip()))
-        name = cutils.match_with_format(args.directory, args.format, it['in']).groupdict()['name']  # type: ignore
+        name = cutils.match_with_format(args.format, it['in']).groupdict()['name']  # type: ignore
         path = cutils.path_from_format(args.directory, args.format, name=name, ext='out')
         with path.open('wb') as fh:
             fh.write(answer)

--- a/onlinejudge/implementation/command/test.py
+++ b/onlinejudge/implementation/command/test.py
@@ -39,7 +39,7 @@ def test(args: 'argparse.Namespace') -> None:
         args.test = cutils.glob_with_format(args.directory, args.format)  # by default
     if args.ignore_backup:
         args.test = cutils.drop_backup_or_hidden_files(args.test)
-    tests = cutils.construct_relationship_of_files(args.test, args.directory, args.format)
+    tests = cutils.construct_relationship_of_files(args.test, args.format)
     if args.error: # float mode
         match = lambda a, b: compare_as_floats(a, b, args.error)
     else:
@@ -55,7 +55,7 @@ def test(args: 'argparse.Namespace') -> None:
     slowest_name = ''
     ac_count = 0
 
-    history = []
+    history = []  # type: List[Dict[str, Any]]
     for name, it in sorted(tests.items()):
         is_printed_input = not args.print_input
         def print_input():

--- a/onlinejudge/implementation/command/utils.py
+++ b/onlinejudge/implementation/command/utils.py
@@ -30,11 +30,11 @@ def match_with_format(format: str, path: pathlib.Path) -> Optional[Match[str]]:
     table = {}
     table['s'] = '(?P<name>.+)'
     table['e'] = '(?P<ext>in|out)'
-    format_root_path = path  # type: str
+    format_root_path = path  # type: pathlib.Path
     for i in range(counts_included_dirname(format)):
         format_root_path = format_root_path.parent
     pattern = re.compile('^' + str(format_root_path) + '/' + utils.parcentformat(format, table) + '$')
-    return pattern.match(str(path))
+    return pattern.match(str(path.resolve()))
 
 def path_from_format(directory: pathlib.Path, format: str, name: str, ext: str) -> pathlib.Path:
     table = {}

--- a/onlinejudge/implementation/command/utils.py
+++ b/onlinejudge/implementation/command/utils.py
@@ -19,12 +19,22 @@ def glob_with_format(directory: pathlib.Path, format: str) -> List[pathlib.Path]
         log.debug('testcase globbed: %s', path)
     return paths
 
+def counts_included_dirname(format: str) -> int:
+    count = 0  # type: int
+    for dirname in format.split('/'):
+        if dirname:
+            count += 1
+    return count
+
 def match_with_format(format: str, path: pathlib.Path) -> Optional[Match[str]]:
     table = {}
     table['s'] = '(?P<name>.+)'
     table['e'] = '(?P<ext>in|out)'
-    pattern = re.compile('^' + utils.parcentformat(format, table) + '$')
-    return pattern.match(path.name)
+    format_root_path = path  # type: str
+    for i in range(counts_included_dirname(format)):
+        format_root_path = format_root_path.parent
+    pattern = re.compile('^' + str(format_root_path) + '/' + utils.parcentformat(format, table) + '$')
+    return pattern.match(str(path))
 
 def path_from_format(directory: pathlib.Path, format: str, name: str, ext: str) -> pathlib.Path:
     table = {}

--- a/onlinejudge/implementation/command/utils.py
+++ b/onlinejudge/implementation/command/utils.py
@@ -19,12 +19,11 @@ def glob_with_format(directory: pathlib.Path, format: str) -> List[pathlib.Path]
         log.debug('testcase globbed: %s', path)
     return paths
 
-def match_with_format(directory: pathlib.Path, format: str, path: pathlib.Path) -> Optional[Match[str]]:
+def match_with_format(format: str, path: pathlib.Path) -> Optional[Match[str]]:
     table = {}
     table['s'] = '(?P<name>.+)'
     table['e'] = '(?P<ext>in|out)'
     pattern = re.compile('^' + utils.parcentformat(format, table) + '$')
-    path = path.absolute().relative_to(directory.absolute()).resolve()
     return pattern.match(str(path))
 
 def path_from_format(directory: pathlib.Path, format: str, name: str, ext: str) -> pathlib.Path:
@@ -46,10 +45,10 @@ def drop_backup_or_hidden_files(paths: List[pathlib.Path]) -> List[pathlib.Path]
             result += [ path ]
     return result
 
-def construct_relationship_of_files(paths: List[pathlib.Path], directory: pathlib.Path, format: str) -> Dict[str, Dict[str, pathlib.Path]]:
+def construct_relationship_of_files(paths: List[pathlib.Path], format: str) -> Dict[str, Dict[str, pathlib.Path]]:
     tests = collections.defaultdict(dict)  # type: Dict[str, Dict[str, pathlib.Path]]
     for path in paths:
-        m = match_with_format(directory, format, path.resolve())
+        m = match_with_format(format, path.resolve())
         if not m:
             log.error('unrecognizable file found: %s', path)
             sys.exit(1)

--- a/onlinejudge/implementation/command/utils.py
+++ b/onlinejudge/implementation/command/utils.py
@@ -24,7 +24,7 @@ def match_with_format(format: str, path: pathlib.Path) -> Optional[Match[str]]:
     table['s'] = '(?P<name>.+)'
     table['e'] = '(?P<ext>in|out)'
     pattern = re.compile('^' + utils.parcentformat(format, table) + '$')
-    return pattern.match(str(path))
+    return pattern.match(path.name)
 
 def path_from_format(directory: pathlib.Path, format: str, name: str, ext: str) -> pathlib.Path:
     table = {}

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -155,7 +155,7 @@ class TestTest(unittest.TestCase):
 
     def test_call_test_dir(self):
         self.snippet_call_test(
-            args=[ '-c', 'cat', '-d', 'path/to/../../p/o/y/o' ],
+            args=[ '-c', 'cat', '-d', 'p/o/../../p/o/y/o' ],
             files=[
                 { 'path': 'p/o/y/o/sample-1.in', 'data': 'foo\n' },
                 { 'path': 'p/o/y/o/sample-1.out', 'data': 'foo\n' },


### PR DESCRIPTION
/home/ryo/work/github/rust-debug/src/
というディレクトリにおいて
oj test -c ./a.out -d ./testを行うと、
```
Traceback (most recent call last):
  File "/home/ryo/.virtualenvs/default/bin/oj", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/ryo/work/github/online-judge-tools/oj", line 6, in <module>
    onlinejudge.implementation.main.main(args=sys.argv[1:])
  File "/home/ryo/work/github/online-judge-tools/onlinejudge/implementation/main.py", line 345, in main
    run_program(namespace, parser=parser)
  File "/home/ryo/work/github/online-judge-tools/onlinejudge/implementation/main.py", line 320, in run_program
    test(args)
  File "/home/ryo/work/github/online-judge-tools/onlinejudge/implementation/command/test.py", line 41, in test
    tests = cutils.construct_relationship_of_files(args.test, args.directory, args.format)
  File "/home/ryo/work/github/online-judge-tools/onlinejudge/implementation/command/utils.py", line 52, in construct_relationship_of_files
    m = match_with_format(directory, format, path.resolve())
  File "/home/ryo/work/github/online-judge-tools/onlinejudge/implementation/command/utils.py", line 27, in match_with_format
    path = path.absolute().relative_to(directory.absolute()).resolve()
  File "/usr/lib/python3.5/pathlib.py", line 1109, in resolve
    s = self._flavour.resolve(self)
  File "/usr/lib/python3.5/pathlib.py", line 330, in resolve
    return _resolve(base, str(path)) or sep
  File "/usr/lib/python3.5/pathlib.py", line 315, in _resolve
    target = accessor.readlink(newpath)
  File "/usr/lib/python3.5/pathlib.py", line 422, in readlink
    return os.readlink(path)
FileNotFoundError: [Errno 2] No such file or directory: '/home/ryo/work/github/rust-debug/src/sample-1.in'

```
というエラーが発生します。
私がローカルで修正を試みたパッチを添えておきます。
実行環境: Python 3.5、https://atcoder.jp/contests/arc087/tasks/arc087_b の問題をダウンロード