### PR TITLE
#276: fix some parts of LOGIN_WITH_COOKIES.md

### DIFF
--- a/LOGIN_WITH_COOKIES.md
+++ b/LOGIN_WITH_COOKIES.md
@@ -1,43 +1,45 @@
 # Login with cookies
 
-If you don't want to give my password to this program, you can use this giving only your session tokens. 
+If you don't want to give your password to this program, you can use this giving only your session tokens. 
 
 Here, we explain about logging in yukicoder (Japanese online judge service).
 In yukicoder, You can login with password or github account or twitter account.
 
 1. Login yukicoder with the browser.
 
-Please access https://yukicoder.me/ and log in with the browser.
+Please access <https://yukicoder.me/> and log in with the browser.
 
 2. Get cookies from the browser.
 
 I used chrome with ["EditThisCookie" Plugin](https://chrome.google.com/webstore/detail/editthiscookie/fngmhnnpilhplaeedifhccceomclgfbg?), but you can choose other plugin or other browser.
 
-Please copy REVEL_SESSION value.
+Please copy `REVEL_SESSION` value.
 
 ![GetCookie](https://user-images.githubusercontent.com/8858287/52058622-31674e80-25ab-11e9-840d-f3960aee8711.png)
 
 3. Generate dummy session token. (Template for rewriting later.)
 
-```
-$ oj login -u dummy -p dummy https://yukicoder.me/
-
-[x] service recognized: <onlinejudge.service.yukicoder.YukicoderService object at 0x7fb468d332b0>: https://yukicoder.me/
-[x] load cookie from: /home/ryo/.local/share/online-judge-tools/cookie.jar
-[x] GET: https://yukicoder.me/auth/github
+``` console
+$ oj d --dry-run https://yukicoder.me/problems/no/9000
+[x] problem recognized: <onlinejudge.service.yukicoder.YukicoderProblem object at 0x7fb84ffca358>: https://yukicoder.me/problems/no/9000
+[x] load cookie from: ~/.local/share/online-judge-tools/cookie.jar
+[x] GET: https://yukicoder.me/problems/no/9000
 [x] 200 OK
-[x] POST: https://github.com/session
-[x] 200 OK
-[-] You failed to sign in. Wrong user ID or password.
-[x] save cookie to: /home/ryo/.local/share/online-judge-tools/cookie.jar
+[x] save cookie to: ~/.local/share/online-judge-tools/cookie.jar
+
+[*] sample 0
+[x] input: サンプル1 入力
+yukicoder
+[x] output: サンプル1 出力
+Hello World!
 ```
 
-Since where cookie.jar is saved depends on the environment, you have to confirm that by console message.
-In this case, cookie.jar is saved to `/home/ryo/.local/share/online-judge-tools/cookie.jar`.
+Since where `cookie.jar` is saved depends on the environment, you have to confirm that by console message.
+In this case, `cookie.jar` is saved to `~/.local/share/online-judge-tools/cookie.jar`.
 
-4. Edit cookie.jar.
+4. Edit `cookie.jar`.
 
-Open cookie.jar with your text editer, you can find session cookie for yukicoder.
+Open `cookie.jar` with your text editer, you can find session cookie for yukicoder.
 
 ```
 Set-Cookie3: REVEL_SESSION="XXXXX"; path="/"; domain="yukicoder.me"; path_spec; expires="2019-02-28 14:53:09Z"; HttpOnly=None; version=0
@@ -47,15 +49,14 @@ Please replace current `REVEL_SESSION` value to value which you copied by the br
 
 5. Confirm logged in.
 
-```
+``` console
 $ oj login https://yukicoder.me/
-
 [x] service recognized: <onlinejudge.service.yukicoder.YukicoderService object at 0x7f4467a0a2b0>: https://yukicoder.me/
-[x] load cookie from: /home/ryo/.local/share/online-judge-tools/cookie.jar
+[x] load cookie from: ~/.local/share/online-judge-tools/cookie.jar
 [x] GET: https://yukicoder.me/auth/github
 [x] 200 OK
 [*] You have already signed in.
-[x] save cookie to: /home/ryo/.local/share/online-judge-tools/cookie.jar
+[x] save cookie to: ~/.local/share/online-judge-tools/cookie.jar
 ```
 
 You can find the sentence `You have already signed in.`.


### PR DESCRIPTION
-   手順3はアクセスがあればよくてloginを試す必要はなさそうなので修正
-   いくつかの文字列をquoteしたり色を付けたりする
-   (実際の出力としては嘘だけど、何も考えずコピペする人のために) `/home/ryo` を `~` で置き換え