### PR TITLE
#314 + snip too large outputs for all subcommands

### DIFF
--- a/onlinejudge/implementation/command/download.py
+++ b/onlinejudge/implementation/command/download.py
@@ -74,7 +74,7 @@ def download(args: 'argparse.Namespace') -> None:
             path = args.directory / utils.percentformat(args.format, table)  # type: pathlib.Path
             log.status('%sput: %s', ext, name)
             if not args.silent:
-                log.emit(utils.snip_large_text(data.rstrip(), limit=40, head=20, tail=10, bold=True))
+                log.emit(utils.snip_large_file_content(data.rstrip(), limit=40, head=20, tail=10, bold=True))
             if args.dry_run:
                 continue
             if path.exists():

--- a/onlinejudge/implementation/command/download.py
+++ b/onlinejudge/implementation/command/download.py
@@ -74,7 +74,7 @@ def download(args: 'argparse.Namespace') -> None:
             path = args.directory / utils.percentformat(args.format, table)  # type: pathlib.Path
             log.status('%sput: %s', ext, name)
             if not args.silent:
-                log.emit(colorama.Style.BRIGHT + data.rstrip() + colorama.Style.RESET_ALL)
+                log.emit(utils.snip_large_text(data.rstrip(), limit=40, head=20, tail=10, bold=True))
             if args.dry_run:
                 continue
             if path.exists():

--- a/onlinejudge/implementation/command/generate_output.py
+++ b/onlinejudge/implementation/command/generate_output.py
@@ -34,7 +34,7 @@ def generate_output(args: 'argparse.Namespace') -> None:
             log.failure(log.red('RE') + ': return code %d', proc.returncode)
             log.info('skipped.')
             continue
-        log.emit(utils.snip_large_text(answer.decode().rstrip(), limit=40, head=20, tail=10, bold=True))
+        log.emit(utils.snip_large_file_content(answer.decode().rstrip(), limit=40, head=20, tail=10, bold=True))
         match_result = cutils.match_with_format(args.directory, args.format, it['in'])  # type: Optional[Match[Any]]
         if match_result is not None:
             matched_name = match_result.groupdict()['name']  # type: str

--- a/onlinejudge/implementation/command/generate_output.py
+++ b/onlinejudge/implementation/command/generate_output.py
@@ -34,7 +34,7 @@ def generate_output(args: 'argparse.Namespace') -> None:
             log.failure(log.red('RE') + ': return code %d', proc.returncode)
             log.info('skipped.')
             continue
-        log.emit(log.bold(answer.decode().rstrip()))
+        log.emit(utils.snip_large_text(answer.decode().rstrip(), limit=40, head=20, tail=10, bold=True))
         match_result = cutils.match_with_format(args.directory, args.format, it['in'])  # type: Optional[Match[Any]]
         if match_result is not None:
             matched_name = match_result.groupdict()['name']  # type: str

--- a/onlinejudge/implementation/command/submit.py
+++ b/onlinejudge/implementation/command/submit.py
@@ -60,7 +60,7 @@ def submit(args: 'argparse.Namespace') -> None:
     if len(lines) < 30:
         log.emit(log.bold(s))
     else:
-        log.emit(log.bold(''.join(lines[:10])))
+        log.emit(log.bold(''.join(lines[:10]).rstrip()))
         log.emit('... (%s lines) ...', len(lines[10:-10]))
         log.emit(log.bold(''.join(lines[-10:])))
 

--- a/onlinejudge/implementation/command/submit.py
+++ b/onlinejudge/implementation/command/submit.py
@@ -56,13 +56,7 @@ def submit(args: 'argparse.Namespace') -> None:
         log.failure('%s: %s', e.__class__.__name__, str(e))
         s = repr(code)[1:]
     log.info('code (%d byte):', len(code))
-    lines = s.splitlines(keepends=True)
-    if len(lines) < 30:
-        log.emit(log.bold(s))
-    else:
-        log.emit(log.bold(''.join(lines[:10]).rstrip()))
-        log.emit('... (%s lines) ...', len(lines[10:-10]))
-        log.emit(log.bold(''.join(lines[-10:])))
+    log.emit(utils.snip_large_text(s.rstrip(), limit=30, head=10, tail=10, bold=True))
 
     with utils.with_cookiejar(utils.new_default_session(), path=args.cookie) as sess:
         # guess or select language ids

--- a/onlinejudge/implementation/command/submit.py
+++ b/onlinejudge/implementation/command/submit.py
@@ -56,7 +56,7 @@ def submit(args: 'argparse.Namespace') -> None:
         log.failure('%s: %s', e.__class__.__name__, str(e))
         s = repr(code)[1:]
     log.info('code (%d byte):', len(code))
-    log.emit(utils.snip_large_text(s.rstrip(), limit=30, head=10, tail=10, bold=True))
+    log.emit(utils.snip_large_file_content(s.rstrip(), limit=30, head=10, tail=10, bold=True))
 
     with utils.with_cookiejar(utils.new_default_session(), path=args.cookie) as sess:
         # guess or select language ids

--- a/onlinejudge/implementation/command/test.py
+++ b/onlinejudge/implementation/command/test.py
@@ -71,7 +71,7 @@ def test(args: 'argparse.Namespace') -> None:
             if not is_printed_input:
                 is_printed_input = True
                 with open(it['in']) as inf:
-                    log.emit('input:\n%s', utils.snip_large_text(inf.read(), limit=40, head=20, tail=10, bold=True))
+                    log.emit('input:\n%s', utils.snip_large_file_content(inf.read(), limit=40, head=20, tail=10, bold=True))
 
         log.emit('')
         log.info('%s', name)
@@ -110,8 +110,8 @@ def test(args: 'argparse.Namespace') -> None:
                     log.failure(log.red('WA'))
                     print_input()
                     if not args.silent:
-                        log.emit('output:\n%s', utils.snip_large_text(answer, limit=40, head=20, tail=10, bold=True))
-                        log.emit('expected:\n%s', utils.snip_large_text(correct, limit=40, head=20, tail=10, bold=True))
+                        log.emit('output:\n%s', utils.snip_large_file_content(answer, limit=40, head=20, tail=10, bold=True))
+                        log.emit('expected:\n%s', utils.snip_large_file_content(correct, limit=40, head=20, tail=10, bold=True))
                     result = 'WA'
             elif args.mode == 'line':
                 answer_words = answer.splitlines()
@@ -135,7 +135,7 @@ def test(args: 'argparse.Namespace') -> None:
                 assert False
         else:
             if not args.silent:
-                log.emit(utils.snip_large_text(answer, limit=40, head=20, tail=10, bold=True))
+                log.emit(utils.snip_large_file_content(answer, limit=40, head=20, tail=10, bold=True))
         if result == 'AC':
             log.success(log.green('AC'))
             ac_count += 1

--- a/onlinejudge/implementation/command/test.py
+++ b/onlinejudge/implementation/command/test.py
@@ -71,7 +71,7 @@ def test(args: 'argparse.Namespace') -> None:
             if not is_printed_input:
                 is_printed_input = True
                 with open(it['in']) as inf:
-                    log.emit('input:\n%s', log.bold(inf.read()))
+                    log.emit('input:\n%s', utils.snip_large_text(inf.read(), limit=40, head=20, tail=10, bold=True))
 
         log.emit('')
         log.info('%s', name)
@@ -110,8 +110,8 @@ def test(args: 'argparse.Namespace') -> None:
                     log.failure(log.red('WA'))
                     print_input()
                     if not args.silent:
-                        log.emit('output:\n%s', log.bold(answer))
-                        log.emit('expected:\n%s', log.bold(correct))
+                        log.emit('output:\n%s', utils.snip_large_text(answer, limit=40, head=20, tail=10, bold=True))
+                        log.emit('expected:\n%s', utils.snip_large_text(correct, limit=40, head=20, tail=10, bold=True))
                     result = 'WA'
             elif args.mode == 'line':
                 answer_words = answer.splitlines()
@@ -135,7 +135,7 @@ def test(args: 'argparse.Namespace') -> None:
                 assert False
         else:
             if not args.silent:
-                log.emit(log.bold(answer))
+                log.emit(utils.snip_large_text(answer, limit=40, head=20, tail=10, bold=True))
         if result == 'AC':
             log.success(log.green('AC'))
             ac_count += 1

--- a/onlinejudge/implementation/utils.py
+++ b/onlinejudge/implementation/utils.py
@@ -275,3 +275,17 @@ def getter_with_load_details(name: str, check_with: Optional[str] = None) -> Cal
         return attr
 
     return wrapper
+
+
+def snip_large_text(text: str, limit: int, head: int, tail: int, bold: bool = False) -> str:
+    assert head + tail < limit
+    font = log.bold if bold else (lambda s: s)
+    lines = text.splitlines(keepends=True)
+    if len(lines) < limit:
+        return font(text)
+    else:
+        return ''.join([
+            font(''.join(lines[:head])),
+            '... ({} lines) ...\n'.format(len(lines[head:-tail])),
+            font(''.join(lines[-tail:])),
+        ])

--- a/onlinejudge/implementation/utils.py
+++ b/onlinejudge/implementation/utils.py
@@ -277,7 +277,7 @@ def getter_with_load_details(name: str, check_with: Optional[str] = None) -> Cal
     return wrapper
 
 
-def snip_large_text(text: str, limit: int, head: int, tail: int, bold: bool = False) -> str:
+def snip_large_file_content(text: str, limit: int, head: int, tail: int, bold: bool = False) -> str:
     assert head + tail < limit
     font = log.bold if bold else (lambda s: s)
     lines = text.splitlines(keepends=True)


### PR DESCRIPTION
close #314 

出力が次のようになります。
「ちゃんと取得ミスがないか確認しろよ」という意図での出力なのに、すべて出力すると確認にならないどころか他の警告まで隠してしまう場合がありました。これを直します。

「省略なし」を指定するオプションも必要になってしまってつらいですが、これはしかたないので諦めて足す予定です。適切なオプション名を考えてないので別のプルリクになります。

```
test_call_submit_beta_3_b (tests.command_submit.SubmitCodeforcesTest) ... [x] read history from: /home/user/.cache/online-judge-tools/download-history.jsonl
[x] found urls in history:

[x] problem recognized: <onlinejudge.service.codeforces.CodeforcesProblem object at 0x7f2c814bda20>: https://codeforces.com/contest/3/problem/B
[*] code (1477 byte):
#include <bits/stdc++.h>
#define REP(i, n) for (int i = 0; (i) < (int)(n); ++ (i))
#define ALL(x) begin(x), end(x)
using namespace std;

int main() {
    // input
    int n, v; cin >> n >> v;
    vector<pair<int, int> > one;
    vector<tuple<int, int, int> > two;
... (40 lines) ...
    }

    // output
    cout << sum_p << endl;
    REP (i, used.size()) {
        cout << used[i] + 1 << (i + 1 < used.size() ? ' ' : '\n');
    }
    return 0;
}
// 1550886839
[x] load cookie from: /home/user/.local/share/online-judge-tools/cookie.jar
[x] GET: https://codeforces.com/contest/3/problem/B
[x] 200 OK
[x] both GCC and Clang are available for C++ compiler
[x] use: GCC
[*] chosen language: 54 (GNU G++17 7.3.0)
[!] the problem "https://codeforces.com/contest/3/problem/B" is specified to submit, but no samples were downloaded in this directory. this may be mis-operation
[x] sleep(3.00)
[x] GET: https://codeforces.com/contest/3/problem/B
[x] 200 OK
[x] POST: https://codeforces.com/contest/3/problem/B?csrf_token=d761c9ef2148312173d0ae719336b416
[x] 200 OK
[+] success: result: https://codeforces.com/contest/3/my
[x] save cookie to: /home/user/.local/share/online-judge-tools/cookie.jar
ok
```

```
test_call_download_aoj_2511 (tests.command_download_aoj.DownloadAOJTest) ... [x] problem recognized: <onlinejudge.service.aoj.AOJProblem object at 0x7f7c9f4e1c88>: http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=2511
[x] load cookie from: /home/user/.local/share/online-judge-tools/cookie.jar
[x] GET: https://judgedat.u-aizu.ac.jp/testcases/samples/2511
[x] 200 OK
[x] save cookie to: /home/user/.local/share/online-judge-tools/cookie.jar
[x] append history to: /home/user/.cache/online-judge-tools/download-history.jsonl

[*] sample 0
[x] input: 1
3 3
1
2
3
1 2 1
1 3 1
2 3 10
3 2
100
10000
1000000
1 2 2
1 3 3
6 6
2
3
5
7
11
13
... (84 lines) ...
7 19 340021
19 11 803293
8 18 692318
9 6 626882
20 2 592133
2 17 196463
12 14 506077
16 20 928375
12 18 894053
0 0
[+] saved to: test/sample-1.in
[x] output: 1
11
5
0
2013
9658580
[+] saved to: test/sample-1.out
ok
```