### PR TITLE
#318: remove problem.get_standings()

### DIFF
--- a/onlinejudge/_implementation/command/get_standings.py
+++ b/onlinejudge/_implementation/command/get_standings.py
@@ -18,7 +18,7 @@ def get_standings(args: 'argparse.Namespace') -> None:
         sys.exit(1)
 
     # get standings
-    header, rows = problem.get_standings()
+    header, rows = problem.get_standings()  # type: ignore
 
     # print it
     if args.format in ['csv', 'tsv']:

--- a/onlinejudge/service/topcoder.py
+++ b/onlinejudge/service/topcoder.py
@@ -173,7 +173,7 @@ class TopcoderLongContestProblem(onlinejudge.type.Problem):
             log.failure('%s', messages)
             raise onlinejudge.type.SubmissionError
 
-    def get_standings(self, session: Optional[requests.Session] = None) -> onlinejudge.type.Standings:
+    def get_standings(self, session: Optional[requests.Session] = None) -> Tuple[List[str], List[Dict[str, Any]]]:
         session = session or utils.new_default_session()
 
         header = None  # type: Optional[List[str]]

--- a/onlinejudge/type.py
+++ b/onlinejudge/type.py
@@ -28,7 +28,6 @@ LabeledString = NamedTuple('LabeledString', [('name', str), ('data', str)])
 TestCase = NamedTuple('TestCase', [('input', LabeledString), ('output', LabeledString)])
 # Language = NamedTuple('Language', [ ('id', str), ('name', str), ('description': str) ])
 Language = Dict[str, Any]
-Standings = Tuple[List[str], List[Dict[str, Any]]]  # ( [ 'column1', 'column2', ... ], [ { 'column1': data1, ... } ... ] )
 
 
 class SubmissionError(RuntimeError):
@@ -58,9 +57,6 @@ class Problem(object):
         raise NotImplementedError
 
     def get_input_format(self, session: Optional[requests.Session] = None) -> Optional[str]:
-        raise NotImplementedError
-
-    def get_standings(self, session: Optional[requests.Session] = None) -> Standings:
         raise NotImplementedError
 
     @classmethod


### PR DESCRIPTION
`problem.get_standings()` is used only for Topcoder Marathon Match. This should be removed from the abstract class `Problem`