### PR TITLE
#375: prepare the global default session

### DIFF
--- a/onlinejudge/_implementation/command/download.py
+++ b/onlinejudge/_implementation/command/download.py
@@ -41,7 +41,7 @@ def download(args: 'argparse.Namespace') -> None:
         args.format = '%b.%e'
 
     # get samples from the server
-    with utils.with_cookiejar(utils.new_default_session(), path=args.cookie) as sess:
+    with utils.with_cookiejar(utils.new_session_with_our_user_agent(), path=args.cookie) as sess:
         if args.system:
             try:
                 samples = problem.download_system_cases(session=sess)  # type: ignore

--- a/onlinejudge/_implementation/command/generate_scanner.py
+++ b/onlinejudge/_implementation/command/generate_scanner.py
@@ -195,7 +195,7 @@ def generate_scanner(args: 'argparse.Namespace') -> None:
     problem = onlinejudge.dispatch.problem_from_url(args.url)
     if problem is None:
         sys.exit(1)
-    with utils.with_cookiejar(utils.new_default_session(), path=args.cookie) as sess:
+    with utils.with_cookiejar(utils.new_session_with_our_user_agent(), path=args.cookie) as sess:
         it = problem.get_input_format(session=sess)  # type: Any
     if not it:
         log.error('input format not found')

--- a/onlinejudge/_implementation/command/login.py
+++ b/onlinejudge/_implementation/command/login.py
@@ -31,7 +31,7 @@ def login(args: 'argparse.Namespace') -> None:
             log.failure('login for %s: invalid option: --method %s', service.get_name(), args.method)
             sys.exit(1)
 
-    with utils.with_cookiejar(utils.new_default_session(), path=args.cookie) as sess:
+    with utils.with_cookiejar(utils.new_session_with_our_user_agent(), path=args.cookie) as sess:
 
         if args.check:
             if service.is_logged_in(session=sess):

--- a/onlinejudge/_implementation/command/submit.py
+++ b/onlinejudge/_implementation/command/submit.py
@@ -54,7 +54,7 @@ def submit(args: 'argparse.Namespace') -> None:
     log.info('code (%d byte):', len(code))
     log.emit(utils.snip_large_file_content(code, limit=30, head=10, tail=10, bold=True))
 
-    with utils.with_cookiejar(utils.new_default_session(), path=args.cookie) as sess:
+    with utils.with_cookiejar(utils.new_session_with_our_user_agent(), path=args.cookie) as sess:
         # guess or select language ids
         langs = {language.id: {'description': language.name} for language in problem.get_available_languages(session=sess)}  # type: Dict[LanguageId, Dict[str, str]]
         matched_lang_ids = None  # type: Optional[List[str]]

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -48,10 +48,23 @@ def next_sibling_tag(tag: bs4.Tag) -> bs4.Tag:
     return tag
 
 
-def new_default_session() -> requests.Session:  # without setting cookiejar
+def new_session_with_our_user_agent() -> requests.Session:
     session = requests.Session()
     session.headers['User-Agent'] += ' (+{})'.format(version.__url__)
     return session
+
+
+_default_session = None  # Optional[requests.Session]
+
+
+def get_default_session() -> requests.Session:
+    """
+    :note: cookie is not saved to disk
+    """
+    global _default_session
+    if _default_session is None:
+        _default_session = new_session_with_our_user_agent()
+    return _default_session
 
 
 default_cookie_path = data_dir / 'cookie.jar'

--- a/onlinejudge/service/anarchygolf.py
+++ b/onlinejudge/service/anarchygolf.py
@@ -39,7 +39,7 @@ class AnarchyGolfProblem(onlinejudge.type.Problem):
         self.problem_id = problem_id
 
     def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[onlinejudge.type.TestCase]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         resp = utils.request('GET', self.get_url(), session=session)
         # parse

--- a/onlinejudge/service/aoj.py
+++ b/onlinejudge/service/aoj.py
@@ -48,7 +48,7 @@ class AOJProblem(onlinejudge.type.Problem):
         self.problem_id = problem_id
 
     def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[TestCase]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get samples via the official API
         # reference: http://developers.u-aizu.ac.jp/api?key=judgedat%2Ftestcases%2Fsamples%2F%7BproblemId%7D_GET
         url = 'https://judgedat.u-aizu.ac.jp/testcases/samples/{}'.format(self.problem_id)
@@ -65,7 +65,7 @@ class AOJProblem(onlinejudge.type.Problem):
         return samples
 
     def download_system_cases(self, session: Optional[requests.Session] = None) -> List[TestCase]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
 
         # get header
         # reference: http://developers.u-aizu.ac.jp/api?key=judgedat%2Ftestcases%2F%7BproblemId%7D%2Fheader_GET

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -62,7 +62,7 @@ class AtCoderService(onlinejudge.type.Service):
         :raises LoginError:
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         if self.is_logged_in(session=session):
             return
 
@@ -92,7 +92,7 @@ class AtCoderService(onlinejudge.type.Service):
             raise LoginError
 
     def is_logged_in(self, session: Optional[requests.Session] = None) -> bool:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://atcoder.jp/contests/practice/submit'
         resp = _request('GET', url, session=session, allow_redirects=False)
         return resp.status_code == 200
@@ -126,7 +126,7 @@ class AtCoderService(onlinejudge.type.Service):
         """
 
         assert lang in ('ja', 'en')
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         last_page = None
         for page in itertools.count(1):  # 1-based
             if last_page is not None and page > last_page:
@@ -232,7 +232,7 @@ class AtCoderContest(object):
         return datetime.datetime.strptime(query['iso'][0], '%Y%m%dT%H%M').replace(tzinfo=utils.tzinfo_jst)
 
     def _load_details(self, session: Optional[requests.Session] = None, lang: Optional[str] = None):
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         resp = _request('GET', self.get_url(type='beta', lang=lang), session=session)
         soup = bs4.BeautifulSoup(resp.content.decode(resp.encoding), utils.html_parser)
 
@@ -284,7 +284,7 @@ class AtCoderContest(object):
 
     def list_problems(self, session: Optional[requests.Session] = None) -> List['AtCoderProblem']:
         # get
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://atcoder.jp/contests/{}/tasks'.format(self.contest_id)
         resp = _request('GET', url, session=session)
 
@@ -320,7 +320,7 @@ class AtCoderContest(object):
             params['desc'] = 'true'
 
         # get
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         for page in itertools.count(1):
             params_page = ({'page': str(page)} if page >= 2 else {})
             url = base_url + '?' + urllib.parse.urlencode({**params, **params_page})
@@ -385,7 +385,7 @@ class AtCoderProblem(onlinejudge.type.Problem):
         :raises Exception: if no such problem exists
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
 
         # get
         resp = _request('GET', self.get_url(type='beta'), raise_for_status=False, session=session)
@@ -491,7 +491,7 @@ class AtCoderProblem(onlinejudge.type.Problem):
         :raises Exception: if no such problem exists
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
 
         # get
         resp = _request('GET', self.get_url(type='beta'), raise_for_status=False, session=session)
@@ -519,7 +519,7 @@ class AtCoderProblem(onlinejudge.type.Problem):
         """
         :raises NotLoggedInError:
         """
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
 
         # get
         resp = _request('GET', self.get_url(type='beta'), session=session)
@@ -545,7 +545,7 @@ class AtCoderProblem(onlinejudge.type.Problem):
         """
 
         assert language_id in [language.id for language in self.get_available_languages(session=session)]
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
 
         # get
         url = 'https://atcoder.jp/contests/{}/submit'.format(self.contest_id)
@@ -579,7 +579,7 @@ class AtCoderProblem(onlinejudge.type.Problem):
             raise SubmissionError('it may be a rate limit')
 
     def _load_details(self, session: Optional[requests.Session] = None) -> None:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
 
         # get
         resp = _request('GET', self.get_url(type='beta', lang='ja'), session=session)
@@ -717,7 +717,7 @@ class AtCoderSubmission(onlinejudge.type.Submission):
         return self.get_source_code(session=session)
 
     def _load_details(self, session: Optional[requests.Session] = None) -> None:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         resp = _request('GET', self.get_url(type='beta', lang='en'), session=session)
         soup = bs4.BeautifulSoup(resp.content.decode(resp.encoding), utils.html_parser)
 

--- a/onlinejudge/service/codeforces.py
+++ b/onlinejudge/service/codeforces.py
@@ -27,7 +27,7 @@ class CodeforcesService(onlinejudge.type.Service):
         """
         :raises LoginError:
         """
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://codeforces.com/enter'
         # get
         resp = utils.request('GET', url, session=session)
@@ -53,7 +53,7 @@ class CodeforcesService(onlinejudge.type.Service):
             raise LoginError('Invalid handle or password.')
 
     def is_logged_in(self, session: Optional[requests.Session] = None) -> bool:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://codeforces.com/enter'
         resp = utils.request('GET', url, session=session, allow_redirects=False)
         return resp.status_code == 302
@@ -97,7 +97,7 @@ class CodeforcesProblem(onlinejudge.type.Problem):
         self.kind = kind  # It seems 'gym' is specialized, 'contest' and 'problemset' are the same thing
 
     def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[onlinejudge.type.TestCase]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         resp = utils.request('GET', self.get_url(), session=session)
         # parse
@@ -124,7 +124,7 @@ class CodeforcesProblem(onlinejudge.type.Problem):
         :raises NotLoggedInError:
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         resp = utils.request('GET', self.get_url(), session=session)
         # parse
@@ -143,7 +143,7 @@ class CodeforcesProblem(onlinejudge.type.Problem):
         :raises SubmissionError:
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         resp = utils.request('GET', self.get_url(), session=session)
         # parse

--- a/onlinejudge/service/csacademy.py
+++ b/onlinejudge/service/csacademy.py
@@ -41,7 +41,7 @@ class CSAcademyProblem(onlinejudge.type.Problem):
         self.task_name = task_name
 
     def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[TestCase]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         base_url = self.get_url()
 
         # get csrftoken

--- a/onlinejudge/service/hackerrank.py
+++ b/onlinejudge/service/hackerrank.py
@@ -30,7 +30,7 @@ class HackerRankService(onlinejudge.type.Service):
         :raises LoginError:
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://www.hackerrank.com/auth/login'
         # get
         resp = utils.request('GET', url, session=session)
@@ -61,7 +61,7 @@ class HackerRankService(onlinejudge.type.Service):
             raise LoginError('You failed to sign in. Wrong user ID or password.')
 
     def is_logged_in(self, session: Optional[requests.Session] = None) -> bool:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://www.hackerrank.com/auth/login'
         resp = utils.request('GET', url, session=session)
         return '/auth' not in resp.url
@@ -95,7 +95,7 @@ class HackerRankProblem(onlinejudge.type.Problem):
         raise NotImplementedError
 
     def download_system_cases(self, session: Optional[requests.Session] = None) -> List[TestCase]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # example: https://www.hackerrank.com/rest/contests/hourrank-1/challenges/beautiful-array/download_testcases
         url = 'https://www.hackerrank.com/rest/contests/{}/challenges/{}/download_testcases'.format(self.contest_slug, self.challenge_slug)
         resp = utils.request('GET', url, session=session, raise_for_status=False)
@@ -133,7 +133,7 @@ class HackerRankProblem(onlinejudge.type.Problem):
         :raises SubmissionError:
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         url = 'https://www.hackerrank.com/rest/contests/{}/challenges/{}'.format(self.contest_slug, self.challenge_slug)
         resp = utils.request('GET', url, session=session)
@@ -146,7 +146,7 @@ class HackerRankProblem(onlinejudge.type.Problem):
         return it['model']
 
     def _get_lang_display_mapping(self, session: Optional[requests.Session] = None) -> Dict[str, str]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         url = 'https://hrcdn.net/hackerrank/assets/codeshell/dist/codeshell-cdffcdf1564c6416e1a2eb207a4521ce.js'  # at "Mon Feb  4 14:51:27 JST 2019"
         resp = utils.request('GET', url, session=session)
@@ -165,7 +165,7 @@ class HackerRankProblem(onlinejudge.type.Problem):
         return lang_display_mapping
 
     def get_available_languages(self, session: Optional[requests.Session] = None) -> List[Language]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         info = self._get_model(session=session)
         lang_display_mapping = self._get_lang_display_mapping()
         result = []  # type: List[Language]
@@ -183,7 +183,7 @@ class HackerRankProblem(onlinejudge.type.Problem):
         :raises SubmissionError:
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         if not self.get_service().is_logged_in(session=session):
             raise NotLoggedInError
         # get

--- a/onlinejudge/service/kattis.py
+++ b/onlinejudge/service/kattis.py
@@ -50,7 +50,7 @@ class KattisProblem(onlinejudge.type.Problem):
         self.problem_id = problem_id
 
     def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[onlinejudge.type.TestCase]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         url = self.get_url(contests=False) + '/file/statement/samples.zip'
         resp = utils.request('GET', url, session=session, raise_for_status=False)

--- a/onlinejudge/service/poj.py
+++ b/onlinejudge/service/poj.py
@@ -39,7 +39,7 @@ class POJProblem(onlinejudge.type.Problem):
         self.problem_id = problem_id
 
     def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[TestCase]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         resp = utils.request('GET', self.get_url(), session=session)
         # parse

--- a/onlinejudge/service/topcoder.py
+++ b/onlinejudge/service/topcoder.py
@@ -30,7 +30,7 @@ class TopcoderService(onlinejudge.type.Service):
         """
         :raises LoginError:
         """
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
 
         # NOTE: you can see this login page with https://community.topcoder.com/longcontest/?module=Submit
         url = 'https://community.topcoder.com/longcontest/'
@@ -105,7 +105,7 @@ class TopcoderLongContestProblem(onlinejudge.type.Problem):
         return None
 
     def get_available_languages(self, session: Optional[requests.Session] = None) -> List[Language]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
 
         return [
             Language(LanguageId('1'), 'Java 8'),
@@ -123,7 +123,7 @@ class TopcoderLongContestProblem(onlinejudge.type.Problem):
         """
 
         assert kind in ['example', 'full']
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
 
         # TODO: implement self.is_logged_in()
         # if not self.is_logged_in(session=session):
@@ -191,7 +191,7 @@ class TopcoderLongContestProblem(onlinejudge.type.Problem):
         .. deprecated:: 6.0.0
             This method may be deleted in future.
         """
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
 
         header = None  # type: Optional[List[str]]
         rows = []  # type: List[Dict[str, str]]

--- a/onlinejudge/service/toph.py
+++ b/onlinejudge/service/toph.py
@@ -25,7 +25,7 @@ class TophService(onlinejudge.type.Service):
         """
         :raises LoginError:
         """
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://toph.co/login'
         # get
         resp = utils.request('GET', url, session=session)
@@ -53,7 +53,7 @@ class TophService(onlinejudge.type.Service):
             raise LoginError('Invalid handle/email or password.')
 
     def is_logged_in(self, session: Optional[requests.Session] = None) -> bool:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://toph.co/login'
         resp = utils.request('GET', url, session=session, allow_redirects=False)
         return resp.status_code != 200
@@ -88,7 +88,7 @@ class TophProblem(onlinejudge.type.Problem):
         self.problem_id = problem_id
 
     def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[onlinejudge.type.TestCase]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         resp = utils.request('GET', self.get_url(), session=session)
         soup = bs4.BeautifulSoup(resp.content.decode(resp.encoding), utils.html_parser)
         samples = onlinejudge._implementation.testcase_zipper.SampleZipper()
@@ -108,7 +108,7 @@ class TophProblem(onlinejudge.type.Problem):
         """
         :raises NotImplementedError:
         """
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         resp = utils.request('GET', self.get_url(), session=session)
         # parse
@@ -126,7 +126,7 @@ class TophProblem(onlinejudge.type.Problem):
         :raises NotImplementedError:
         :raises SubmissionError:
         """
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         resp = utils.request('GET', self.get_url(), session=session)
         # parse

--- a/onlinejudge/service/yukicoder.py
+++ b/onlinejudge/service/yukicoder.py
@@ -39,7 +39,7 @@ class YukicoderService(onlinejudge.type.Service):
         :raise LoginError:
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://yukicoder.me/auth/github'
         # get
         resp = utils.request('GET', url, session=session)
@@ -72,12 +72,12 @@ class YukicoderService(onlinejudge.type.Service):
         :raise NotImplementedError: always raised
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://yukicoder.me/auth/twitter'
         raise NotImplementedError
 
     def is_logged_in(self, session: Optional[requests.Session] = None, method: Optional[str] = None) -> bool:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         url = 'https://yukicoder.me/auth/github'
         resp = utils.request('GET', url, session=session, allow_redirects=False)
         assert resp.status_code == 302
@@ -107,7 +107,7 @@ class YukicoderService(onlinejudge.type.Service):
         else:
             assert name is not None
             url = 'https://yukicoder.me/api/v1/{}/name/{}'.format(api, urllib.parse.quote(name))
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         try:
             resp = utils.request('GET', url, session=session)
         except requests.exceptions.HTTPError:
@@ -264,7 +264,7 @@ class YukicoderService(onlinejudge.type.Service):
 
     def _get_and_parse_the_table(self, url: str, session: Optional[requests.Session] = None) -> Tuple[List[Any], List[Dict[str, bs4.Tag]]]:
         # get
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         resp = utils.request('GET', url, session=session)
         # parse
         soup = bs4.BeautifulSoup(resp.content.decode(resp.encoding), utils.html_parser)
@@ -294,7 +294,7 @@ class YukicoderProblem(onlinejudge.type.Problem):
         self.problem_id = problem_id
 
     def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[TestCase]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         resp = utils.request('GET', self.get_url(), session=session)
         # parse
@@ -313,7 +313,7 @@ class YukicoderProblem(onlinejudge.type.Problem):
         :raises NotLoggedInError:
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         if not self.get_service().is_logged_in(session=session):
             raise NotLoggedInError
         url = 'https://yukicoder.me/problems/no/{}/testcase.zip'.format(self.problem_no)
@@ -338,7 +338,7 @@ class YukicoderProblem(onlinejudge.type.Problem):
         :raises NotLoggedInError:
         """
 
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         url = self.get_url() + '/submit'
         resp = utils.request('GET', url, session=session)
@@ -368,7 +368,7 @@ class YukicoderProblem(onlinejudge.type.Problem):
             raise SubmissionError
 
     def get_available_languages(self, session: Optional[requests.Session] = None) -> List[Language]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         # We use the problem page since it is available without logging in
         resp = utils.request('GET', self.get_url(), session=session)
@@ -413,7 +413,7 @@ class YukicoderProblem(onlinejudge.type.Problem):
         return YukicoderService()
 
     def get_input_format(self, session: Optional[requests.Session] = None) -> Optional[str]:
-        session = session or utils.new_default_session()
+        session = session or utils.get_default_session()
         # get
         resp = utils.request('GET', self.get_url(), session=session)
         # parse


### PR DESCRIPTION
例えば次のような流れのコードが (1行目でログインが成功したとしても) 2行目で `NotLoggedInError` みたいになるのはかなり不親切に思えるので、global変数を用いてこれを解決します。

``` python
problem.get_service().login()
problem.submit_code(code)
```