### PR TITLE
NONE: set long_description_content_type = text/markdown at setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 long_description = file: readme.md
+long_description_content_type = text/markdown
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console


### PR DESCRIPTION
現状は readme がそのまま表示されてて汚ない (https://pypi.org/project/online-judge-tools/0.1.55/) のですが、これを解決します。
https://packaging.python.org/guides/making-a-pypi-friendly-readme/ によると、これを指定するといい感じにしてくれるらしいです。