### PR TITLE
#393: fix the degression of the `submit` subcommand for Topcoder with `--full-submission`

### DIFF
--- a/onlinejudge/_implementation/command/login.py
+++ b/onlinejudge/_implementation/command/login.py
@@ -19,7 +19,7 @@ def login(args: 'argparse.Namespace') -> None:
 
     # configure
     kwargs = {}
-    if service.get_name() == 'yukicoder':
+    if isinstance(service, onlinejudge.service.yukicoder.YukicoderService):
         if not args.method:
             args.method = 'github'
         if args.method not in ['github', 'twitter']:

--- a/onlinejudge/_implementation/command/submit.py
+++ b/onlinejudge/_implementation/command/submit.py
@@ -128,7 +128,7 @@ def submit(args: 'argparse.Namespace') -> None:
 
         # submit
         kwargs = {}
-        if problem.get_service().get_name() == 'topcoder':
+        if isinstance(problem, onlinejudge.service.topcoder.TopcoderLongContestProblem):
             if args.full_submission:
                 kwargs['kind'] = 'full'
             else:

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -163,6 +163,8 @@ def request(method: str, url: str, session: requests.Session, raise_for_status: 
     assert method in ['GET', 'POST']
     kwargs.setdefault('allow_redirects', True)
     log.status('%s: %s', method, url)
+    if 'data' in kwargs:
+        log.debug('data: %s', repr(kwargs['data']))
     resp = session.request(method, url, **kwargs)
     if resp.url != url:
         log.status('redirected: %s', resp.url)


### PR DESCRIPTION
close #393 

上のようないかにもバグの温床な書き方をしてたのが原因なので、ちゃんと下のように直しました

https://github.com/kmyk/online-judge-tools/blob/5ae56183b6b92a1cba5c0b39dcb7e21a03c89708/onlinejudge/_implementation/command/submit.py#L131
https://github.com/kmyk/online-judge-tools/blob/ff7bb1b419f5dc90cadc0b359842743d6b51bd39/onlinejudge/_implementation/command/submit.py#L131