### PR TITLE
#402: add the class AtCoderProblemContent

### DIFF
--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -296,8 +296,18 @@ class DummySubmission(Submission):
         self.url = url
         self.problem = problem
 
+    def download_code(self, session: Optional[requests.Session] = None) -> bytes:
+        raise NotImplementedError
+
     def get_url(self) -> str:
         return self.url
 
     def get_problem(self) -> Problem:
         return self.problem
+
+    def get_service(self) -> Service:
+        raise NotImplementedError
+
+    @classmethod
+    def from_url(cls, s: str) -> Optional[Submission]:
+        return None

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -308,6 +308,9 @@ class DummySubmission(Submission):
     def get_service(self) -> Service:
         raise NotImplementedError
 
+    def __repr__(self) -> str:
+        return '{}({}, problem={})'.format(self.__class__, self.url, self.problem)
+
     @classmethod
     def from_url(cls, s: str) -> Optional[Submission]:
         return None

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -500,6 +500,9 @@ def _AtCoderProblemContent_parse_score(soup: bs4.BeautifulSoup) -> Optional[int]
 def _AtCoderProblemContent_from_html(html: str, problem: 'AtCoderProblem') -> AtCoderProblemContent:
     """
     :param html: must be a HTML of the new (beta) version of AtCoder
+
+    .. versionadded:: 6.2.0
+
     """
 
     soup = bs4.BeautifulSoup(html, utils.html_parser)
@@ -534,6 +537,8 @@ class AtCoderProblem(onlinejudge.type.Problem):
     def download_content(self, session: Optional[requests.Session] = None) -> AtCoderProblemContent:
         """
         :raises Exception: if no such problem exists
+
+        .. versionadded:: 6.2.0
         """
 
         session = session or utils.get_default_session()
@@ -676,6 +681,7 @@ class AtCoderProblem(onlinejudge.type.Problem):
     def get_score(self, session: Optional[requests.Session] = None) -> Optional[int]:
         """
         :return: :py:data:`None` if the problem has no score  (e.g. https://atcoder.jp/contests/abc012/tasks/abc012_3)
+
         .. deprecated:: 6.2.0
         """
         warnings.warn('deprecated', DeprecationWarning)

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -399,27 +399,21 @@ def _AtCoderProblemContent_find_sample_tags(soup: bs4.BeautifulSoup) -> Generato
         log.debug('pre tag: %s', str(pre))
         if not pre.string:
             continue
-        prv = utils.previous_sibling_tag(pre)
+
+        def h3_plus(tag):
+            prv = tag.find_previous_sibling()
+            if prv and prv.name == 'h3' and prv.string:
+                yield (pre, prv)
 
         # the first format: h3+pre
-        if prv and prv.name == 'h3' and prv.string:
-            yield (pre, prv)
+        yield from h3_plus(pre)
 
-        else:
+        # the second format: h3+section pre
+        if pre.parent and pre.parent.name == 'section':
             # ignore tags which are not samples
             # example: https://atcoder.jp/contests/abc003/tasks/abc003_4
-            while prv is not None:
-                if prv.name == 'pre':
-                    break
-                prv = utils.previous_sibling_tag(prv)
-            if prv is not None:
-                continue
-
-            # the second format: h3+section pre
-            if pre.parent and pre.parent.name == 'section':
-                prv = pre.parent and utils.previous_sibling_tag(pre.parent)
-                if prv and prv.name == 'h3' and prv.string:
-                    yield (pre, prv)
+            if pre.find_previous_sibling('pre') is None:
+                yield from h3_plus(pre.parent)
 
 
 def _AtCoderProblemContent_parse_sample_cases(soup: bs4.BeautifulSoup) -> List[onlinejudge.type.TestCase]:

--- a/onlinejudge/service/topcoder.py
+++ b/onlinejudge/service/topcoder.py
@@ -85,6 +85,12 @@ class TopcoderLongContestProblem(onlinejudge.type.Problem):
     def get_service(self) -> TopcoderService:
         return TopcoderService()
 
+    def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[onlinejudge.type.TestCase]:
+        """
+        :raises NotImplementedError:
+        """
+        raise NotImplementedError
+
     @classmethod
     def from_url(cls, url: str) -> Optional['TopcoderLongContestProblem']:
         # example: https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=16997&pm=14690

--- a/onlinejudge/type.py
+++ b/onlinejudge/type.py
@@ -1,4 +1,5 @@
 # Python Version: 3.x
+from abc import ABC, abstractmethod
 from typing import Callable, List, NamedTuple, NewType, Optional, Tuple
 
 import requests
@@ -10,7 +11,7 @@ class LoginError(RuntimeError):
     pass
 
 
-class Service(object):
+class Service(ABC):
     def login(self, get_credentials: CredentialsProvider, session: Optional[requests.Session] = None) -> None:
         """
         :param get_credentials: returns a tuple of (username, password)
@@ -21,9 +22,11 @@ class Service(object):
     def is_logged_in(self, session: Optional[requests.Session] = None) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
     def get_url(self) -> str:
         raise NotImplementedError
 
+    @abstractmethod
     def get_name(self) -> str:
         """
         example:
@@ -37,6 +40,7 @@ class Service(object):
         raise NotImplementedError
 
     @classmethod
+    @abstractmethod
     def from_url(self, s: str) -> Optional['Service']:
         pass
 
@@ -72,7 +76,8 @@ class SubmissionError(RuntimeError):
     pass
 
 
-class Problem(object):
+class Problem(ABC):
+    @abstractmethod
     def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[TestCase]:
         raise NotImplementedError
 
@@ -94,9 +99,11 @@ class Problem(object):
     def get_available_languages(self, session: Optional[requests.Session] = None) -> List[Language]:
         raise NotImplementedError
 
+    @abstractmethod
     def get_url(self) -> str:
         raise NotImplementedError
 
+    @abstractmethod
     def get_service(self) -> Service:
         raise NotImplementedError
 
@@ -118,23 +125,29 @@ class Problem(object):
         raise NotImplementedError
 
     @classmethod
+    @abstractmethod
     def from_url(self, s: str) -> Optional['Problem']:
         pass
 
 
-class Submission(object):
+class Submission(ABC):
+    @abstractmethod
     def download_code(self, session: Optional[requests.Session] = None) -> bytes:
         raise NotImplementedError
 
+    @abstractmethod
     def get_url(self) -> str:
         raise NotImplementedError
 
+    @abstractmethod
     def get_problem(self) -> Problem:
         raise NotImplementedError
 
+    @abstractmethod
     def get_service(self) -> Service:
         return self.get_problem().get_service()
 
     @classmethod
+    @abstractmethod
     def from_url(cls, s: str) -> Optional['Submission']:
         pass

--- a/onlinejudge/type.py
+++ b/onlinejudge/type.py
@@ -39,6 +39,12 @@ class Service(ABC):
         """
         raise NotImplementedError
 
+    def __repr__(self) -> str:
+        return '{}.from_url({})'.format(self.__class__.__name__, repr(self.get_url()))
+
+    def __eq__(self, other) -> bool:
+        return self.__class__ == other.__class__ and self.get_url() == other.get_url()
+
     @classmethod
     @abstractmethod
     def from_url(self, s: str) -> Optional['Service']:
@@ -77,6 +83,10 @@ class SubmissionError(RuntimeError):
 
 
 class Problem(ABC):
+    """
+    :note: :py:class:`Problem` represents just a URL of a problem, without the data of the problem.
+    """
+
     @abstractmethod
     def download_sample_cases(self, session: Optional[requests.Session] = None) -> List[TestCase]:
         raise NotImplementedError
@@ -124,6 +134,12 @@ class Problem(ABC):
 
         raise NotImplementedError
 
+    def __repr__(self) -> str:
+        return '{}.from_url({})'.format(self.__class__.__name__, repr(self.get_url()))
+
+    def __eq__(self, other) -> bool:
+        return self.__class__ == other.__class__ and self.get_url() == other.get_url()
+
     @classmethod
     @abstractmethod
     def from_url(self, s: str) -> Optional['Problem']:
@@ -146,6 +162,12 @@ class Submission(ABC):
     @abstractmethod
     def get_service(self) -> Service:
         return self.get_problem().get_service()
+
+    def __repr__(self) -> str:
+        return '{}.from_url({})'.format(self.__class__.__name__, repr(self.get_url()))
+
+    def __eq__(self, other) -> bool:
+        return self.__class__ == other.__class__ and self.get_url() == other.get_url()
 
     @classmethod
     @abstractmethod

--- a/tests/service_atcoder.py
+++ b/tests/service_atcoder.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from onlinejudge.service.atcoder import AtCoderContest, AtCoderProblem, AtCoderService, AtCoderSubmission
+import requests
+
+from onlinejudge.service.atcoder import AtCoderContest, AtCoderProblem, AtCoderProblemContent, AtCoderService, AtCoderSubmission
+from onlinejudge.type import TestCase
 
 
 class AtCoderSerivceTest(unittest.TestCase):
@@ -182,6 +185,29 @@ class AtCoderSubmissionTest(unittest.TestCase):
         submission = AtCoderSubmission.from_url('https://atcoder.jp/contests/abc100/submissions/4317534')
         self.assertEqual(submission.get_source_code(), b'/9\\|\\B/c:(\r\ncYay!\r\n')
         self.assertEqual(submission.get_code_size(), 19)
+
+
+class AtCoderProblemContentTest(unittest.TestCase):
+    def test_from_html(self):
+        url = 'https://atcoder.jp/contests/abc114/tasks/abc114_d'
+        resp = requests.get(url)
+        html = resp.content.decode(resp.apparent_encoding)
+        content = AtCoderProblemContent.from_html(html, problem=AtCoderProblem.from_url(url))
+
+        self.assertEqual(content.alphabet, 'D')
+        self.assertEqual(content.available_languages, None)
+        self.assertEqual(content.html, html)
+        self.assertEqual(content.input_format, '<var>N</var>\r\n')
+        self.assertEqual(content.memory_limit_byte, 1024 * 1000 * 1000)
+        self.assertEqual(content.name, '756')
+        self.assertEqual(content.problem, AtCoderProblem.from_url(url))
+        self.assertEqual(content.sample_cases, [
+            TestCase(name='sample-1', input_name='入力例 1', input_data=b'9\n', output_name='出力例 1', output_data=b'0\n'),
+            TestCase(name='sample-2', input_name='入力例 2', input_data=b'10\n', output_name='出力例 2', output_data=b'1\n'),
+            TestCase(name='sample-3', input_name='入力例 3', input_data=b'100\n', output_name='出力例 3', output_data=b'543\n'),
+        ])
+        self.assertEqual(content.score, 400)
+        self.assertEqual(content.time_limit_msec, 2 * 1000)
 
 
 class AtCoderProblemGetInputFormatTest(unittest.TestCase):

--- a/tests/service_atcoder.py
+++ b/tests/service_atcoder.py
@@ -86,6 +86,15 @@ class AtCoderProblemTest(unittest.TestCase):
         self.assertEqual(AtCoderProblem.from_url('https://atcoder.jp/contests/agc030/tasks/agc030_c').contest_id, 'agc030')
         self.assertEqual(AtCoderProblem.from_url('https://atcoder.jp/contests/agc030/tasks/agc030_c').problem_id, 'agc030_c')
 
+    def test_repr(self):
+        self.assertEqual(repr(AtCoderProblem('kupc2014', 'kupc2014_d')), "AtCoderProblem.from_url('https://atcoder.jp/contests/kupc2014/tasks/kupc2014_d')")
+        self.assertEqual(repr(AtCoderProblem('agc030', 'agc030_c')), "AtCoderProblem.from_url('https://atcoder.jp/contests/agc030/tasks/agc030_c')")
+        self.assertEqual(repr(AtCoderProblem('xxxxxx', 'yyyyyy')), "AtCoderProblem.from_url('https://atcoder.jp/contests/xxxxxx/tasks/yyyyyy')")
+
+    def test_eq(self):
+        self.assertEqual(AtCoderProblem.from_url('https://kupc2014.contest.atcoder.jp/tasks/kupc2014_d'), AtCoderProblem.from_url('https://atcoder.jp/contests/kupc2014/tasks/kupc2014_d'))
+        self.assertNotEqual(AtCoderProblem.from_url('https://kupc2014.contest.atcoder.jp/tasks/kupc2014_d'), AtCoderProblem.from_url('https://atcoder.jp/contests/agc030/tasks/agc030_c'))
+
     def test_load_details(self):
         problem = AtCoderProblem.from_url('https://atcoder.jp/contests/abc118/tasks/abc118_a')
         self.assertEqual(problem.get_alphabet(), 'A')

--- a/tests/type.py
+++ b/tests/type.py
@@ -1,0 +1,10 @@
+import unittest
+
+from onlinejudge.type import Problem, Service, Submission
+
+
+class TypeTest(unittest.TestCase):
+    def test_instantiate_abstract_class(self):
+        self.assertRaises(TypeError, Service)
+        self.assertRaises(TypeError, Problem)
+        self.assertRaises(TypeError, Submission)


### PR DESCRIPTION
close #402

- `abc.ABC` や `__repr__` は機能というより設計方針を明確にするためのドキュメントのつもりです
- 差分は小さくないですが、どれもすべて元々あったコードを移動したものです
- コードは汚ないですが、インターフェースの綺麗さを優先した結果です (これは Python 3.5 の対応を切れば解決します https://docs.python.org/ja/3.6/library/typing.html#typing.NamedTuple)
- テストは何も削っていません
- 後方互換性はすべて保ったはずです

@fukatani レビューお願いします :pray: