### PR TITLE
#403: add a feature to download MatchOverview of Topcoder Marathon Match

### DIFF
--- a/onlinejudge/service/topcoder.py
+++ b/onlinejudge/service/topcoder.py
@@ -329,6 +329,27 @@ class TopcoderLongContestProblem(onlinejudge.type.Problem):
             testcases += [TopcoderLongContestProblemIndividualResultsFeedTestCase(test_case_id, score, processing_time, fatal_error_ind)]
         return TopcoderLongContestProblemIndividualResultsFeed(round_id, coder_id, handle, submissions, testcases)
 
+    def download_system_test(self, test_case_id: int, session: Optional[requests.Session] = None) -> str:
+        """
+        :raises NotLoggedInError:
+        :note: You need to parse this result manually.
+
+        .. versionadded:: 6.2.0
+            This method may be deleted in future.
+        """
+        session = session or utils.get_default_session()
+
+        # get
+        assert self.pm is not None
+        url = 'https://community.topcoder.com/longcontest/stats/?module=ViewSystemTest&rd={}&pm={}&tid={}'.format(self.rd, self.pm, test_case_id)
+        resp = utils.request('GET', url, session=session)
+
+        # parse
+        soup = bs4.BeautifulSoup(resp.content.decode(resp.encoding), utils.html_parser)
+        if soup.find('form', attrs={'name': 'frmLogin'}):
+            raise NotLoggedInError
+        return soup.find('pre').text
+
 
 onlinejudge.dispatch.services += [TopcoderService]
 onlinejudge.dispatch.problems += [TopcoderLongContestProblem]

--- a/onlinejudge/service/topcoder.py
+++ b/onlinejudge/service/topcoder.py
@@ -306,26 +306,30 @@ class TopcoderLongContestProblem(onlinejudge.type.Problem):
         resp = utils.request('GET', url, session=session)
 
         # parse
+        def get_text_at(node: xml.etree.ElementTree.Element, i: int) -> str:
+            text = list(node)[i].text
+            if text is None:
+                raise ValueError
+            return text
+
         root = xml.etree.ElementTree.fromstring(resp.content.decode(resp.encoding))
         assert len(list(root)) == 5
-        round_id = int(list(root)[0].text or '')  # NOTE: `or ''` is for the typechecker
-        coder_id = int(list(root)[1].text or '')
-        handle = list(root)[2].text
-        assert handle is not None
+        round_id = int(get_text_at(root, 0))
+        coder_id = int(get_text_at(root, 1))
+        handle = get_text_at(root, 2)
         submissions = []  # type: List[TopcoderLongContestProblemIndividualResultsFeedSubmission]
         for submission in list(root)[3]:
-            number = int(list(submission)[0].text or '')
-            score = float(list(submission)[1].text or '')
-            language = list(submission)[2].text or ''
-            time = list(submission)[3].text
-            assert time is not None
+            number = int(get_text_at(submission, 0))
+            score = float(get_text_at(submission, 1))
+            language = get_text_at(submission, 2)
+            time = get_text_at(submission, 3)
             submissions += [TopcoderLongContestProblemIndividualResultsFeedSubmission(number, score, language, time)]
         testcases = []  # type: List[TopcoderLongContestProblemIndividualResultsFeedTestCase]
         for testcase in list(root)[4]:
-            test_case_id = int(list(testcase)[0].text or '')
-            score = float(list(testcase)[1].text or '')
-            processing_time = int(list(testcase)[2].text or '')
-            fatal_error_ind = int(list(testcase)[3].text or '')
+            test_case_id = int(get_text_at(testcase, 0))
+            score = float(get_text_at(testcase, 1))
+            processing_time = int(get_text_at(testcase, 2))
+            fatal_error_ind = int(get_text_at(testcase, 3))
             testcases += [TopcoderLongContestProblemIndividualResultsFeedTestCase(test_case_id, score, processing_time, fatal_error_ind)]
         return TopcoderLongContestProblemIndividualResultsFeed(round_id, coder_id, handle, submissions, testcases)
 

--- a/tests/service_topcoder.py
+++ b/tests/service_topcoder.py
@@ -13,3 +13,15 @@ class TopcoderLongConrestProblemTest(unittest.TestCase):
     def test_from_url(self):
         self.assertEqual(TopcoderLongContestProblem.from_url('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17092&pm=14853').rd, 17092)
         self.assertEqual(TopcoderLongContestProblem.from_url('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17092&pm=14853').pm, 14853)
+
+    def test_download_overview(self):
+        problem = TopcoderLongContestProblem.from_url('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17143&pm=14889')
+        overview = problem.download_overview()
+        self.assertEqual(len(overview), 282)
+        self.assertEqual(overview[4].rank, 5)
+        self.assertEqual(overview[4].handle, 'hakomo')
+        self.assertEqual(overview[4].provisional_rank, 6)
+        self.assertAlmostEqual(overview[4].provisional_score, 812366.55)
+        self.assertAlmostEqual(overview[4].final_score, 791163.70)
+        self.assertEqual(overview[4].language, 'C++')
+        self.assertEqual(overview[4].cr, 22924522)

--- a/tests/service_topcoder.py
+++ b/tests/service_topcoder.py
@@ -1,5 +1,7 @@
+import os
 import unittest
 
+import onlinejudge._implementation.utils as utils
 from onlinejudge.service.topcoder import TopcoderLongContestProblem, TopcoderService
 
 
@@ -43,3 +45,43 @@ class TopcoderLongConrestProblemTest(unittest.TestCase):
         self.assertEqual(feed.testcases[0].fatal_error_ind, 0)
         self.assertEqual(len(feed.submissions), 5)
         self.assertEqual(len(feed.testcases), 2000)
+
+    @unittest.skipIf('CI' in os.environ, 'login is required')
+    def test_download_system_test(self):
+        with utils.with_cookiejar(utils.get_default_session()):
+            url = 'https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17143&pm=14889'
+            tid = 33800773
+            problem = TopcoderLongContestProblem.from_url(url)
+            self.assertEqual(problem.download_system_test(tid), 'seed = 1919427468645\nH = 85\nW = 88\nC = 2\n')
+
+        with utils.with_cookiejar(utils.get_default_session()):
+            url = 'https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17092&pm=14853'
+            tid = 33796324
+            problem = TopcoderLongContestProblem.from_url(url)
+            self.assertEqual(problem.download_system_test(tid), """\
+Seed = 2917103922548
+
+Coins: 5372
+Max Time: 2988
+Note Time: 5
+Num Machines: 3
+
+Machine 0...
+Wheel 0: ACEEDEDBDGBADCDFGD
+Wheel 1: GGFEFBFDFFDEECFEAG
+Wheel 2: EFCCCAADBDGEGBDCDD
+Expected payout rate: 1.5775034293552812
+
+Machine 1...
+Wheel 0: CDFFDEEEAGGGGGFGGBEFCCFFFD
+Wheel 1: EDCGBGFBBCCGGFGDFBFECGGEFC
+Wheel 2: GEDECEGFDCGDGGCDDCEDGBGEBG
+Expected payout rate: 0.7345243513882568
+
+Machine 2...
+Wheel 0: ABEEDDDCGBG
+Wheel 1: EDEEDADGEAF
+Wheel 2: EBEGEFEGEBF
+Expected payout rate: 0.6160781367392938
+
+""")

--- a/tests/service_topcoder.py
+++ b/tests/service_topcoder.py
@@ -25,3 +25,21 @@ class TopcoderLongConrestProblemTest(unittest.TestCase):
         self.assertAlmostEqual(overview[4].final_score, 791163.70)
         self.assertEqual(overview[4].language, 'C++')
         self.assertEqual(overview[4].cr, 22924522)
+
+    def test_download_individual_results_feed(self):
+        problem = TopcoderLongContestProblem.from_url('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17143&pm=14889')
+        cr = 22924522
+        feed = problem.download_individual_results_feed(cr)
+        self.assertEqual(feed.round_id, problem.rd)
+        self.assertEqual(feed.coder_id, cr)
+        self.assertEqual(feed.handle, 'hakomo')
+        self.assertEqual(feed.submissions[0].number, 1)
+        self.assertAlmostEqual(feed.submissions[0].score, 816622.81)
+        self.assertEqual(feed.submissions[0].language, 'C++')
+        self.assertEqual(feed.submissions[0].time, '04/22/2018 09:56:48')
+        self.assertEqual(feed.testcases[0].test_case_id, 33800773)
+        self.assertAlmostEqual(feed.testcases[0].score, 1.0)
+        self.assertEqual(feed.testcases[0].processing_time, 164)
+        self.assertEqual(feed.testcases[0].fatal_error_ind, 0)
+        self.assertEqual(len(feed.submissions), 5)
+        self.assertEqual(len(feed.testcases), 2000)

--- a/tests/service_topcoder.py
+++ b/tests/service_topcoder.py
@@ -1,0 +1,15 @@
+import unittest
+
+from onlinejudge.service.topcoder import TopcoderLongContestProblem, TopcoderService
+
+
+class TopcoderSerivceTest(unittest.TestCase):
+    def test_from_url(self):
+        self.assertIsInstance(TopcoderService.from_url('https://community.topcoder.com/'), TopcoderService)
+        self.assertIsNone(TopcoderService.from_url('https://atcoder.jp/'))
+
+
+class TopcoderLongConrestProblemTest(unittest.TestCase):
+    def test_from_url(self):
+        self.assertEqual(TopcoderLongContestProblem.from_url('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17092&pm=14853').rd, 17092)
+        self.assertEqual(TopcoderLongContestProblem.from_url('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17092&pm=14853').pm, 14853)


### PR DESCRIPTION
close #403 

かなりそのままな形で実装しました。
`cr` `rd` のような妙な名前は Topcoder 側のしている省略に合わせています。
型名がすごく長いですが、短くするよりましだと思ったのでこうなってます。