### PR TITLE
Update the feature to use module=ViewStandings of Topcoder Marathon Match

### DIFF
--- a/tests/service_topcoder.py
+++ b/tests/service_topcoder.py
@@ -16,6 +16,11 @@ class TopcoderLongConrestProblemTest(unittest.TestCase):
         self.assertEqual(TopcoderLongContestProblem.from_url('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17092&pm=14853').rd, 17092)
         self.assertEqual(TopcoderLongContestProblem.from_url('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17092&pm=14853').pm, 14853)
 
+    # TODO: write a mock test
+    def test_download_standings_expired(self):
+        problem = TopcoderLongContestProblem.from_url('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17143&pm=14889')
+        self.assertRaises(Exception, problem.download_standings)
+
     def test_download_overview(self):
         problem = TopcoderLongContestProblem.from_url('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17143&pm=14889')
         overview = problem.download_overview()


### PR DESCRIPTION
#406 のついでです。

- 型を変えたので互換性は壊れました
- method名を変えたのはついでです。変えても問題ないタイミングで「毎回通信が発生しそうな」名前にしたかった
- テストがないのは仕様です。コンテスト開催中しか動かないのでテストには mock を書くしかなくて面倒です。加えて、ユーザの性質 (MMに参加していて、順位表の解析という発想を持っていて、Pythonライブラリを利用できる) から、彼らからのバグ報告が来ることに頼ってしまってよいはずです