### PR TITLE
#409: remove sympy from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ install_requires =
     colorama >= 0.3
     lxml >= 4
     requests >= 2
-    sympy >= 1.1
 scripts =
     oj
 packages = find:


### PR DESCRIPTION
close #409 

不要な依存関係は (ユーザにとって) 邪魔なだけなので消します