### PR TITLE
#412: allow non-integers for memory limits in AtCoder

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -362,7 +362,7 @@ def _AtCoderProblemContentPartial_from_row(tr: bs4.Tag):
     alphabet = tds[0].text
     name = tds[1].text
     time_limit_msec = int(float(utils.remove_suffix(tds[2].text, ' sec')) * 1000)
-    memory_limit_byte = int(utils.remove_suffix(tds[3].text, ' MB')) * 1000 * 1000  # TODO: confirm this is MB truly, not MiB
+    memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' MB')) * 1000 * 1000)  # TODO: confirm this is MB truly, not MiB
     if len(tds) == 5:
         assert tds[4].text.strip() in ('', 'Submit', '提出')
 

--- a/tests/service_atcoder.py
+++ b/tests/service_atcoder.py
@@ -72,6 +72,19 @@ class AtCoderContestTest(unittest.TestCase):
         self.assertEqual(problems[6].get_alphabet(), 'F2')
         self.assertEqual(problems[6].problem_id, 'agc028_f2')
 
+    def test_list_problems_with_float_values(self):
+        """
+        .. seealso:
+            https://github.com/kmyk/online-judge-tools/issues/412
+        """
+
+        contest = AtCoderContest.from_url('https://atcoder.jp/contests/dwacon2018-final-open')
+        problems = contest.list_problems()
+        self.assertEqual(problems[0].get_time_limit_msec(), 2525)
+        self.assertEqual(problems[0].get_memory_limit_byte(), int(252.525 * 1000 * 1000))
+        self.assertEqual(problems[1].get_time_limit_msec(), 5252)
+        self.assertEqual(problems[1].get_memory_limit_byte(), int(525.252 * 1000 * 1000))
+
     def test_iterate_submissions(self):
         contest = AtCoderContest.from_url('https://atcoder.jp/contests/code-festival-2014-exhibition-open')
         submissions = list(contest.iterate_submissions())


### PR DESCRIPTION
close #412

運よく byte を単位として持っていたので、型は変えずにそのまま修正できました。