### PR TITLE
#411: add a workaround for the scores surrounded by \( \) in AtCoder

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -487,7 +487,13 @@ def _AtCoderProblemContent_parse_score(soup: bs4.BeautifulSoup) -> Optional[int]
     task_statement = soup.find('div', id='task-statement')
     p = task_statement.find('p')  # first
     if p is not None and p.text.startswith('配点 : '):
-        return int(utils.remove_suffix(utils.remove_prefix(p.text, '配点 : '), ' 点'))
+        score = utils.remove_suffix(utils.remove_prefix(p.text, '配点 : '), ' 点')
+        try:
+            return int(score)
+        except ValueError:
+            # some problems have scores like "<p>配点 : \(100\) 点</p>", not "<p>配点 : 100 点</p>"
+            # example: https://atcoder.jp/contests/wupc2019/tasks/wupc2019_a
+            pass
     return None
 
 

--- a/tests/service_atcoder.py
+++ b/tests/service_atcoder.py
@@ -114,6 +114,14 @@ class AtCoderProblemTest(unittest.TestCase):
         self.assertEqual(AtCoderProblem.from_url('https://atcoder.jp/contests/future-contest-2018-final/tasks/future_contest_2018_final_a').get_score(), 50000000)
         self.assertEqual(AtCoderProblem.from_url('https://atcoder.jp/contests/abc001/tasks/abc001_4').get_score(), None)
 
+    def test_get_score_latex(self):
+        """
+        .. seealso::
+            https://github.com/kmyk/online-judge-tools/issues/411
+        """
+
+        self.assertIsNone(AtCoderProblem.from_url('https://atcoder.jp/contests/wupc2019/tasks/wupc2019_a').get_score())
+
     def test_iterate_submissions(self):
         problem = AtCoderProblem.from_url('https://atcoder.jp/contests/abc119/tasks/abc119_c')
         submissions = problem.iterate_submissions()


### PR DESCRIPTION
close #411 

落ちないようにだけして取得は放棄しています。主には以下の2点が理由です。

1.  他にも `$100$` とか `<var>100</var>` とか色々でてきそう
1.  そもそも点数情報は順位表から取るべきだった