### PR TITLE
[WIP] #423: support the minimalistic versions of Codeforces

### DIFF
--- a/tests/service_codeforces.py
+++ b/tests/service_codeforces.py
@@ -37,3 +37,15 @@ class CodeforcesProblemTest(unittest.TestCase):
         self.assertEqual(CodeforcesProblem.from_url('https://codeforces.com/contest/1133/problem/E').index, 'E')
         self.assertEqual(CodeforcesProblem.from_url('https://codeforces.com/contest/1133/problem/F1').index, 'F1')
         self.assertEqual(CodeforcesProblem.from_url('https://codeforces.com/contest/1133/problem/F2').index, 'F2')
+
+    def test_from_url_subdomains(self):
+        urls = [
+            'https://codeforces.com/contest/1158/problem/C',
+            'https://m1.codeforces.com/contest/1158/problem/C',
+            'https://m2.codeforces.com/contest/1158/problem/C',
+            'https://m3.codeforces.com/contest/1158/problem/C',
+        ]
+        for url in urls:
+            self.assertEqual(CodeforcesProblem.from_url(url).get_url(), url)
+            self.assertEqual(CodeforcesProblem.from_url(url).contest_id, 1158)
+            self.assertEqual(CodeforcesProblem.from_url(url).index, 'C')


### PR DESCRIPTION
close #423 

**まだやりかけ**

-   [ ] 問題の http://m1.codeforces.com/ らは必要のないときには稼動してないので、まだ URL の認識以外の部分のテストはできていません。つぎの Div 3 only 回あたりに動作確認する予定
-   [ ] `codeforces.com` の部分を可変にするの修正漏れ (ないはずだけど) しそうだよね
-   [ ] `CodeforcesService.__init__()` での入力値検証を忘れてる
-   [ ] `m1.codeforces.com` `m2.codeforces.com` `m3.codeforces.com` に限らず `*.codeforces.com` すべてを受け入れてるけど https://polygon.codeforces.com/ のような反例があるので微妙な気がする