### PR TITLE
#429: avoid the limitation of the new API of AOJ

### DIFF
--- a/onlinejudge/service/aoj.py
+++ b/onlinejudge/service/aoj.py
@@ -81,24 +81,16 @@ class AOJProblem(onlinejudge.type.Problem):
         # get testcases via the official API
         testcases = []  # type: List[TestCase]
         for header in header['headers']:
-            # reference: http://developers.u-aizu.ac.jp/api?key=judgedat%2Ftestcases%2F%7BproblemId%7D%2F%7Bserial%7D_GET
+            # NOTE: the endpoints are not same to http://developers.u-aizu.ac.jp/api?key=judgedat%2Ftestcases%2F%7BproblemId%7D%2F%7Bserial%7D_GET since the json API often says "..... (terminated because of the limitation)"
             url = 'https://judgedat.u-aizu.ac.jp/testcases/{}/{}'.format(self.problem_id, header['serial'])
-            resp = utils.request('GET', url, session=session)
-            testcase = json.loads(resp.content.decode(resp.encoding))
-            skipped = False
-            for type in ('in', 'out'):
-                if testcase[type].endswith('..... (terminated because of the limitation)\n'):
-                    log.error('AOJ API says: terminated because of the limitation')
-                    skipped = True
-            if skipped:
-                log.warning("skipped due to the limitation of AOJ API")
-                continue
+            resp_in = utils.request('GET', url + '/in', session=session)
+            resp_out = utils.request('GET', url + '/out', session=session)
             testcases += [TestCase(
                 header['name'],
                 header['name'],
-                testcase['in'].encode(),
+                resp_in.content,
                 header['name'],
-                testcase['out'].encode(),
+                resp_out.content,
             )]
         return testcases
 

--- a/tests/command_download_aoj.py
+++ b/tests/command_download_aoj.py
@@ -59,14 +59,10 @@ class DownloadAOJTest(unittest.TestCase):
         }, is_system=True)
 
     def test_call_download_aoj_system_1169(self):
-        # NOTE: the data exists, but AOJ says "..... (terminated because of the limitation)"
-        self.snippet_call_download(
-            'http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=1169&lang=jp',
-            {
-                # '1.in':  'f0ecaede832a038d0e940c2c4d0ab5e5',
-                # '1.out': '8d2f7846dc2fc10ef37dcb548635c788',
-            },
-            is_system=True)
+        self.snippet_call_download('http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=1169&lang=jp', {
+            'judge_data.in': 'f0ecaede832a038d0e940c2c4d0ab5e5',
+            'judge_data.out': '8d2f7846dc2fc10ef37dcb548635c788',
+        }, is_system=True)
 
 
 class DownloadAOJArenaTest(unittest.TestCase):


### PR DESCRIPTION
close #429 

AOJ のシステムケースを取得する際に `..... (terminated because of the limitation)` と言われて途中で打ち切られる問題がありましたが、これを解決します。