### PR TITLE
enhancement about --tle option

### DIFF
--- a/onlinejudge/_implementation/command/generate_output.py
+++ b/onlinejudge/_implementation/command/generate_output.py
@@ -27,7 +27,7 @@ def generate_output(args: 'argparse.Namespace') -> None:
             continue
         with it['in'].open() as inf:
             begin = time.perf_counter()
-            answer, proc = utils.exec_command(args.command, shell=True, stdin=inf, timeout=args.tle)
+            answer, proc = utils.exec_command(args.command, stdin=inf, timeout=args.tle)
             end = time.perf_counter()
             log.status('time: %f sec', end - begin)
         if proc.returncode is None:

--- a/onlinejudge/_implementation/command/generate_output.py
+++ b/onlinejudge/_implementation/command/generate_output.py
@@ -27,10 +27,14 @@ def generate_output(args: 'argparse.Namespace') -> None:
             continue
         with it['in'].open() as inf:
             begin = time.perf_counter()
-            answer, proc = utils.exec_command(args.command, shell=True, stdin=inf)
+            answer, proc = utils.exec_command(args.command, shell=True, stdin=inf, timeout=args.tle)
             end = time.perf_counter()
             log.status('time: %f sec', end - begin)
-        if proc.returncode != 0:
+        if proc.returncode is None:
+            log.failure(log.red('TLE'))
+            log.info('skipped.')
+            continue
+        elif proc.returncode != 0:
             log.failure(log.red('RE') + ': return code %d', proc.returncode)
             log.info('skipped.')
             continue

--- a/onlinejudge/_implementation/command/test.py
+++ b/onlinejudge/_implementation/command/test.py
@@ -79,7 +79,7 @@ def test(args: 'argparse.Namespace') -> None:
         # run the binary
         with it['in'].open() as inf:
             begin = time.perf_counter()
-            answer_byte, proc = utils.exec_command(args.command, shell=True, stdin=inf, timeout=args.tle)
+            answer_byte, proc = utils.exec_command(args.command, stdin=inf, timeout=args.tle)
             end = time.perf_counter()
             elapsed = end - begin
             answer = answer_byte.decode()  # TODO: the `answer` should be bytes, not str

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -159,6 +159,7 @@ tips:
     subparser.add_argument('-c', '--command', default='./a.out', help='your solution to be tested. (default: "./a.out")')
     subparser.add_argument('-f', '--format', default='%s.%e', help='a format string to recognize the relationship of test cases. (default: "%%s.%%e")')
     subparser.add_argument('-d', '--directory', type=pathlib.Path, default=pathlib.Path('test'), help='a directory name for test cases (default: test/)')
+    subparser.add_argument('-t', '--tle', type=float, help='set the time limit (in second) (default: inf)')
     subparser.add_argument('test', nargs='*', type=pathlib.Path, help='paths of input cases. (if empty: globbed from --format)')
     subparser.add_argument('--no-ignore-backup', action='store_false', dest='ignore_backup')
     subparser.add_argument('--ignore-backup', action='store_true', help='ignore backup files and hidden files (i.e. files like "*~", "\\#*\\#" and ".*") (default)')


### PR DESCRIPTION
close #427 

実行時間制限を付けるオプション `--tle` を、サブコマンド `test` だけでなくサブコマンド `generate-output` でも使えるようにします。
これに伴なって、 `--tle` による実行打ち切り後もプロセスが死なず動き続ける問題の修正もします。

@fukatani レビュー時の注意として:

-   微妙に性質の違うコミットふたつなのでプルリクを分けるべきかもしれないが、衝突するのでまとめました
-   テストがないけど書くの面倒なので許して
-   プロセスの処理はプロセスグループを使ってやるしか手がなかったです。Windows上ではたぶん動かないので無効化しています