### PR TITLE
Bug fix of AtCoderContest.from_url()

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -197,7 +197,7 @@ class AtCoderContest(object):
 
         # example: https://atcoder.jp/contests/agc030
         if result.scheme in ('', 'http', 'https') and result.hostname in ('atcoder.jp', 'beta.atcoder.jp'):
-            m = re.match(r'^/contests/([\w\-_]+)/?$.*', utils.normpath(result.path))
+            m = re.match(r'/contests/([\w\-_]+)/?.*', utils.normpath(result.path))
             if m:
                 contest_id = m.group(1)
                 return cls(contest_id)

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -197,7 +197,7 @@ class AtCoderContest(object):
 
         # example: https://atcoder.jp/contests/agc030
         if result.scheme in ('', 'http', 'https') and result.hostname in ('atcoder.jp', 'beta.atcoder.jp'):
-            m = re.match(r'^/contests/([\w\-_]+)/?$', utils.normpath(result.path))
+            m = re.match(r'^/contests/([\w\-_]+)/?$.*', utils.normpath(result.path))
             if m:
                 contest_id = m.group(1)
                 return cls(contest_id)


### PR DESCRIPTION
For urls like "https://atcoder.jp/contests/abc128/tasks/abc128_a",
AtCoderContest.from_url() returns None.
This commit will fix it.