### PR TITLE
#428: make test possible to run in parallel

### DIFF
--- a/onlinejudge/_implementation/command/generate_output.py
+++ b/onlinejudge/_implementation/command/generate_output.py
@@ -1,10 +1,11 @@
 # Python Version: 3.x
 import os
+import pathlib
 import time
 from typing import *
 
 import onlinejudge
-import onlinejudge._implementation.format_utils as cutils
+import onlinejudge._implementation.format_utils as fmtutils
 import onlinejudge._implementation.logging as log
 import onlinejudge._implementation.utils as utils
 
@@ -12,41 +13,59 @@ if TYPE_CHECKING:
     import argparse
 
 
+def generate_output_single_case(test_name: str, test_input_path: pathlib.Path, *, args: 'argparse.Namespace') -> None:
+    # print the header
+    log.emit('')
+    log.info('%s', test_name)
+
+    # run the command
+    with test_input_path.open() as inf:
+        begin = time.perf_counter()
+        answer, proc = utils.exec_command(args.command, stdin=inf, timeout=args.tle)
+        end = time.perf_counter()
+
+    # check the result
+    log.status('time: %f sec', end - begin)
+    if proc.returncode is None:
+        log.failure(log.red('TLE'))
+        log.info('skipped.')
+        return
+    elif proc.returncode != 0:
+        log.failure(log.red('RE') + ': return code %d', proc.returncode)
+        log.info('skipped.')
+        return
+    log.emit(utils.snip_large_file_content(answer, limit=40, head=20, tail=10, bold=True))
+
+    # find the destination path
+    match_result = fmtutils.match_with_format(args.directory, args.format, test_input_path)  # type: Optional[Match[Any]]
+    if match_result is not None:
+        matched_name = match_result.groupdict()['name']  # type: str
+    else:
+        assert False
+    test_output_path = fmtutils.path_from_format(args.directory, args.format, name=matched_name, ext='out')
+
+    # write the result to the file
+    if not test_output_path.parent.is_dir():
+        os.makedirs(str(test_output_path.parent), exist_ok=True)
+    with test_output_path.open('wb') as fh:
+        fh.write(answer)
+    log.success('saved to: %s', test_output_path)
+
+
 def generate_output(args: 'argparse.Namespace') -> None:
+    # list tests
     if not args.test:
-        args.test = cutils.glob_with_format(args.directory, args.format)  # by default
+        args.test = fmtutils.glob_with_format(args.directory, args.format)  # by default
     if args.ignore_backup:
-        args.test = cutils.drop_backup_or_hidden_files(args.test)
-    tests = cutils.construct_relationship_of_files(args.test, args.directory, args.format)
-    for name, it in sorted(tests.items()):
-        log.emit('')
-        log.info('%s', name)
-        if 'out' in it:
+        args.test = fmtutils.drop_backup_or_hidden_files(args.test)
+    tests = fmtutils.construct_relationship_of_files(args.test, args.directory, args.format)
+
+    # generate cases
+    for name, paths in sorted(tests.items()):
+        if 'out' in paths:
+            log.emit('')
+            log.info('%s', name)
             log.info('output file already exists.')
             log.info('skipped.')
-            continue
-        with it['in'].open() as inf:
-            begin = time.perf_counter()
-            answer, proc = utils.exec_command(args.command, stdin=inf, timeout=args.tle)
-            end = time.perf_counter()
-            log.status('time: %f sec', end - begin)
-        if proc.returncode is None:
-            log.failure(log.red('TLE'))
-            log.info('skipped.')
-            continue
-        elif proc.returncode != 0:
-            log.failure(log.red('RE') + ': return code %d', proc.returncode)
-            log.info('skipped.')
-            continue
-        log.emit(utils.snip_large_file_content(answer, limit=40, head=20, tail=10, bold=True))
-        match_result = cutils.match_with_format(args.directory, args.format, it['in'])  # type: Optional[Match[Any]]
-        if match_result is not None:
-            matched_name = match_result.groupdict()['name']  # type: str
         else:
-            assert False
-        path = cutils.path_from_format(args.directory, args.format, name=matched_name, ext='out')
-        if not path.parent.is_dir():
-            os.makedirs(str(path.parent), exist_ok=True)
-        with path.open('wb') as fh:
-            fh.write(answer)
-        log.success('saved to: %s', path)
+            generate_output_single_case(name, paths['in'], args=args)

--- a/onlinejudge/_implementation/command/generate_output.py
+++ b/onlinejudge/_implementation/command/generate_output.py
@@ -30,7 +30,8 @@ def generate_output_single_case(test_name: str, test_input_path: pathlib.Path, *
         end = time.perf_counter()
 
     # acquire lock to print logs properly, if in parallel
-    with lock or contextlib.ExitStack():
+    nullcontext = contextlib.ExitStack()
+    with lock or nullcontext:
         if lock is not None:
             log.emit('')
             log.info('%s', test_name)
@@ -65,7 +66,8 @@ def generate_output_single_case(test_name: str, test_input_path: pathlib.Path, *
 
 def generate_output_single_case_exists_ok(test_name: str, test_input_path: pathlib.Path, test_output_path: Optional[pathlib.Path], *, lock: Optional[threading.Lock] = None, args: 'argparse.Namespace') -> None:
     if test_output_path is not None:
-        with lock or contextlib.ExitStack():
+        nullcontext = contextlib.ExitStack()
+        with lock or nullcontext:
             log.emit('')
             log.info('%s', test_name)
             log.info('output file already exists.')

--- a/onlinejudge/_implementation/command/generate_output.py
+++ b/onlinejudge/_implementation/command/generate_output.py
@@ -1,6 +1,9 @@
 # Python Version: 3.x
+import concurrent.futures
+import contextlib
 import os
 import pathlib
+import threading
 import time
 from typing import *
 
@@ -13,10 +16,12 @@ if TYPE_CHECKING:
     import argparse
 
 
-def generate_output_single_case(test_name: str, test_input_path: pathlib.Path, *, args: 'argparse.Namespace') -> None:
+def generate_output_single_case(test_name: str, test_input_path: pathlib.Path, *, lock: Optional[threading.Lock] = None, args: 'argparse.Namespace') -> None:
+
     # print the header
-    log.emit('')
-    log.info('%s', test_name)
+    if lock is None:
+        log.emit('')
+        log.info('%s', test_name)
 
     # run the command
     with test_input_path.open() as inf:
@@ -24,32 +29,49 @@ def generate_output_single_case(test_name: str, test_input_path: pathlib.Path, *
         answer, proc = utils.exec_command(args.command, stdin=inf, timeout=args.tle)
         end = time.perf_counter()
 
-    # check the result
-    log.status('time: %f sec', end - begin)
-    if proc.returncode is None:
-        log.failure(log.red('TLE'))
-        log.info('skipped.')
-        return
-    elif proc.returncode != 0:
-        log.failure(log.red('RE') + ': return code %d', proc.returncode)
-        log.info('skipped.')
-        return
-    log.emit(utils.snip_large_file_content(answer, limit=40, head=20, tail=10, bold=True))
+    # acquire lock to print logs properly, if in parallel
+    with lock or contextlib.ExitStack():
+        if lock is not None:
+            log.emit('')
+            log.info('%s', test_name)
 
-    # find the destination path
-    match_result = fmtutils.match_with_format(args.directory, args.format, test_input_path)  # type: Optional[Match[Any]]
-    if match_result is not None:
-        matched_name = match_result.groupdict()['name']  # type: str
+        # check the result
+        log.status('time: %f sec', end - begin)
+        if proc.returncode is None:
+            log.failure(log.red('TLE'))
+            log.info('skipped.')
+            return
+        elif proc.returncode != 0:
+            log.failure(log.red('RE') + ': return code %d', proc.returncode)
+            log.info('skipped.')
+            return
+        log.emit(utils.snip_large_file_content(answer, limit=40, head=20, tail=10, bold=True))
+
+        # find the destination path
+        match_result = fmtutils.match_with_format(args.directory, args.format, test_input_path)  # type: Optional[Match[Any]]
+        if match_result is not None:
+            matched_name = match_result.groupdict()['name']  # type: str
+        else:
+            assert False
+        test_output_path = fmtutils.path_from_format(args.directory, args.format, name=matched_name, ext='out')
+
+        # write the result to the file
+        if not test_output_path.parent.is_dir():
+            os.makedirs(str(test_output_path.parent), exist_ok=True)
+        with test_output_path.open('wb') as fh:
+            fh.write(answer)
+        log.success('saved to: %s', test_output_path)
+
+
+def generate_output_single_case_exists_ok(test_name: str, test_input_path: pathlib.Path, test_output_path: Optional[pathlib.Path], *, lock: Optional[threading.Lock] = None, args: 'argparse.Namespace') -> None:
+    if test_output_path is not None:
+        with lock or contextlib.ExitStack():
+            log.emit('')
+            log.info('%s', test_name)
+            log.info('output file already exists.')
+            log.info('skipped.')
     else:
-        assert False
-    test_output_path = fmtutils.path_from_format(args.directory, args.format, name=matched_name, ext='out')
-
-    # write the result to the file
-    if not test_output_path.parent.is_dir():
-        os.makedirs(str(test_output_path.parent), exist_ok=True)
-    with test_output_path.open('wb') as fh:
-        fh.write(answer)
-    log.success('saved to: %s', test_output_path)
+        generate_output_single_case(test_name, test_input_path, lock=lock, args=args)
 
 
 def generate_output(args: 'argparse.Namespace') -> None:
@@ -61,11 +83,14 @@ def generate_output(args: 'argparse.Namespace') -> None:
     tests = fmtutils.construct_relationship_of_files(args.test, args.directory, args.format)
 
     # generate cases
-    for name, paths in sorted(tests.items()):
-        if 'out' in paths:
-            log.emit('')
-            log.info('%s', name)
-            log.info('output file already exists.')
-            log.info('skipped.')
-        else:
-            generate_output_single_case(name, paths['in'], args=args)
+    if args.jobs is None:
+        for name, paths in sorted(tests.items()):
+            generate_output_single_case_exists_ok(name, paths['in'], paths.get('out'), args=args)
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as executor:
+            lock = threading.Lock()
+            futures = []  # type: List[concurrent.futures.Future]
+            for name, paths in sorted(tests.items()):
+                futures += [executor.submit(generate_output_single_case_exists_ok, name, paths['in'], paths.get('out'), lock=lock, args=args)]
+            for future in futures:
+                future.result()

--- a/onlinejudge/_implementation/command/test.py
+++ b/onlinejudge/_implementation/command/test.py
@@ -1,12 +1,14 @@
 # Python Version: 3.x
 import json
 import math
+import pathlib
+import subprocess
 import sys
 import time
 from typing import *
 
 import onlinejudge
-import onlinejudge._implementation.format_utils as cutils
+import onlinejudge._implementation.format_utils as fmtutils
 import onlinejudge._implementation.logging as log
 import onlinejudge._implementation.utils as utils
 
@@ -38,124 +40,142 @@ def compare_as_floats(xs_: str, ys_: str, error: float) -> bool:
     return True
 
 
-def test(args: 'argparse.Namespace') -> None:
-    # prepare
-    if not args.test:
-        args.test = cutils.glob_with_format(args.directory, args.format)  # by default
-    if args.ignore_backup:
-        args.test = cutils.drop_backup_or_hidden_files(args.test)
-    tests = cutils.construct_relationship_of_files(args.test, args.directory, args.format)
-    if args.error:  # float mode
-        match = lambda a, b: compare_as_floats(a, b, args.error)
+def compare_and_report(proc: subprocess.Popen, answer: str, test_input_path: pathlib.Path, test_output_path: Optional[pathlib.Path], *, mode: str, error: Optional[float], does_print_input: bool, silent: bool, rstrip: bool) -> str:
+    # prepare the comparing function
+    if error:  # float mode
+        match = lambda a, b: compare_as_floats(a, b, error)
     else:
+        rstrip_targets = ' \t\r\n\f\v\0'  # ruby's one, follow AnarchyGolf
 
         def match(a, b):
             if a == b:
                 return True
-            if args.rstrip and a.rstrip(rstrip_targets) == b.rstrip(rstrip_targets):
+            if rstrip and a.rstrip(rstrip_targets) == b.rstrip(rstrip_targets):
                 log.warning('WA if no rstrip')
                 return True
             return False
 
-    rstrip_targets = ' \t\r\n\f\v\0'  # ruby's one, follow AnarchyGolf
+    # prepare the function to print the input
+    is_input_printed = False
+
+    def print_input():
+        nonlocal is_input_printed
+        if does_print_input and not is_input_printed:
+            is_input_printed = True
+            with test_input_path.open('rb') as inf:
+                log.emit('input:\n%s', utils.snip_large_file_content(inf.read(), limit=40, head=20, tail=10, bold=True))
+
+    # check TLE, RE or not
+    status = 'AC'
+    if proc.returncode is None:
+        log.failure(log.red('TLE'))
+        status = 'TLE'
+        print_input()
+    elif proc.returncode != 0:
+        log.failure(log.red('RE') + ': return code %d', proc.returncode)
+        status = 'RE'
+        print_input()
+
+    # check WA or not
+    if test_output_path is not None:
+        with test_output_path.open() as outf:
+            expected = outf.read()
+        # compare
+        if mode == 'all':
+            if not match(answer, expected):
+                log.failure(log.red('WA'))
+                print_input()
+                if not silent:
+                    log.emit('output:\n%s', utils.snip_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
+                    log.emit('expected:\n%s', utils.snip_large_file_content(expected.encode(), limit=40, head=20, tail=10, bold=True))
+                status = 'WA'
+        elif mode == 'line':
+            answer_words = answer.splitlines()
+            correct_words = expected.splitlines()
+            for i, (x, y) in enumerate(zip(answer_words + [None] * len(correct_words), correct_words + [None] * len(answer_words))):  # type: ignore
+                if x is None and y is None:
+                    break
+                elif x is None:
+                    print_input()
+                    log.failure(log.red('WA') + ': line %d: line is nothing: expected "%s"', i + 1, log.bold(y))
+                    status = 'WA'
+                elif y is None:
+                    print_input()
+                    log.failure(log.red('WA') + ': line %d: unexpected line: output "%s"', i + 1, log.bold(x))
+                    status = 'WA'
+                elif not match(x, y):
+                    print_input()
+                    log.failure(log.red('WA') + ': line %d: output "%s": expected "%s"', i + 1, log.bold(x), log.bold(y))
+                    status = 'WA'
+        else:
+            assert False
+    else:
+        if not silent:
+            log.emit(('output:\n%s' if is_input_printed else '%s'), utils.snip_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
+    if status == 'AC':
+        log.success(log.green('AC'))
+
+    return status
+
+
+def test_single_case(test_name: str, test_input_path: pathlib.Path, test_output_path: Optional[pathlib.Path], *, args: 'argparse.Namespace') -> Dict[str, Any]:
+    log.emit('')
+    log.info('%s', test_name)
+
+    # run the binary
+    with test_input_path.open() as inf:
+        begin = time.perf_counter()
+        answer_byte, proc = utils.exec_command(args.command, stdin=inf, timeout=args.tle)
+        end = time.perf_counter()
+        elapsed = end - begin
+        answer = answer_byte.decode()  # TODO: the `answer` should be bytes, not str
+        proc.terminate()
+    log.status('time: %f sec', elapsed)
+
+    status = compare_and_report(proc, answer, test_input_path, test_output_path, mode=args.mode, error=args.error, does_print_input=args.print_input, silent=args.silent, rstrip=args.rstrip)
+
+    # return the result
+    testcase = {
+        'name': test_name,
+        'input': str(test_input_path.resolve()),
+    }
+    if test_output_path:
+        testcase['output'] = str(test_output_path.resolve())
+    result = {
+        'status': status,
+        'testcase': testcase,
+        'output': answer,
+        'exitcode': proc.returncode,
+        'elapsed': elapsed,
+    }
+    return result
+
+
+def test(args: 'argparse.Namespace') -> None:
+    # list tests
+    if not args.test:
+        args.test = fmtutils.glob_with_format(args.directory, args.format)  # by default
+    if args.ignore_backup:
+        args.test = fmtutils.drop_backup_or_hidden_files(args.test)
+    tests = fmtutils.construct_relationship_of_files(args.test, args.directory, args.format)
+
+    # run tests
+    history = []  # type: List[Dict[str, Any]]
+    for name, paths in sorted(tests.items()):
+        history += [test_single_case(name, paths['in'], paths.get('out'), args=args)]
+
+    # summarize
     slowest = -1  # type: Union[int, float]
     slowest_name = ''
     ac_count = 0
-
-    history = []  # type: List[Dict[str, Any]]
-    for name, it in sorted(tests.items()):
-        is_input_printed = False
-
-        def print_input():
-            nonlocal is_input_printed
-            if args.print_input and not is_input_printed:
-                is_input_printed = True
-                with open(it['in'], 'rb') as inf:
-                    log.emit('input:\n%s', utils.snip_large_file_content(inf.read(), limit=40, head=20, tail=10, bold=True))
-
-        log.emit('')
-        log.info('%s', name)
-
-        # run the binary
-        with it['in'].open() as inf:
-            begin = time.perf_counter()
-            answer_byte, proc = utils.exec_command(args.command, stdin=inf, timeout=args.tle)
-            end = time.perf_counter()
-            elapsed = end - begin
-            answer = answer_byte.decode()  # TODO: the `answer` should be bytes, not str
-            if slowest < elapsed:
-                slowest = elapsed
-                slowest_name = name
-            log.status('time: %f sec', elapsed)
-            proc.terminate()
-
-        # check TLE, RE or not
-        result = 'AC'
-        if proc.returncode is None:
-            log.failure(log.red('TLE'))
-            result = 'TLE'
-            print_input()
-        elif proc.returncode != 0:
-            log.failure(log.red('RE') + ': return code %d', proc.returncode)
-            result = 'RE'
-            print_input()
-
-        # check WA or not
-        if 'out' in it:
-            with it['out'].open() as outf:
-                correct = outf.read()
-            # compare
-            if args.mode == 'all':
-                if not match(answer, correct):
-                    log.failure(log.red('WA'))
-                    print_input()
-                    if not args.silent:
-                        log.emit('output:\n%s', utils.snip_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
-                        log.emit('expected:\n%s', utils.snip_large_file_content(correct.encode(), limit=40, head=20, tail=10, bold=True))
-                    result = 'WA'
-            elif args.mode == 'line':
-                answer_words = answer.splitlines()
-                correct_words = correct.splitlines()
-                for i, (x, y) in enumerate(zip(answer_words + [None] * len(correct_words), correct_words + [None] * len(answer_words))):  # type: ignore
-                    if x is None and y is None:
-                        break
-                    elif x is None:
-                        print_input()
-                        log.failure(log.red('WA') + ': line %d: line is nothing: expected "%s"', i + 1, log.bold(y))
-                        result = 'WA'
-                    elif y is None:
-                        print_input()
-                        log.failure(log.red('WA') + ': line %d: unexpected line: output "%s"', i + 1, log.bold(x))
-                        result = 'WA'
-                    elif not match(x, y):
-                        print_input()
-                        log.failure(log.red('WA') + ': line %d: output "%s": expected "%s"', i + 1, log.bold(x), log.bold(y))
-                        result = 'WA'
-            else:
-                assert False
-        else:
-            if not args.silent:
-                log.emit(('output:\n%s' if is_input_printed else '%s'), utils.snip_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
-        if result == 'AC':
-            log.success(log.green('AC'))
+    for result in history:
+        if result['status'] == 'AC':
             ac_count += 1
+        if slowest < result['elapsed']:
+            slowest = result['elapsed']
+            slowest_name = result['testcase']['name']
 
-        # push the result
-        testcase = {
-            'name': name,
-            'input': str(it['in'].resolve()),
-        }
-        if 'out' in it:
-            testcase['output'] = str(it['out'].resolve())
-        history += [{
-            'result': result,
-            'testcase': testcase,
-            'output': answer,
-            'exitcode': proc.returncode,
-            'elapsed': elapsed,
-        }]
-
-    # summarize
+    # print the summary
     log.emit('')
     log.status('slowest: %f sec  (for %s)', slowest, slowest_name)
     if ac_count == len(tests):

--- a/onlinejudge/_implementation/command/test.py
+++ b/onlinejudge/_implementation/command/test.py
@@ -137,7 +137,8 @@ def test_single_case(test_name: str, test_input_path: pathlib.Path, test_output_
         proc.terminate()
 
     # lock is require to avoid mixing logs if in parallel
-    with lock or contextlib.ExitStack():
+    nullcontext = contextlib.ExitStack()  # TODO: use contextlib.nullcontext() after updating Python to 3.7
+    with lock or nullcontext:
         if lock is not None:
             log.emit('')
             log.info('%s', test_name)

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -141,6 +141,7 @@ tips:
     subparser.add_argument('-e', '--error', type=float, help='check as floating point number: correct if its absolute or relative error doesn\'t exceed it')
     subparser.add_argument('-t', '--tle', type=float, help='set the time limit (in second) (default: inf)')
     subparser.add_argument('-i', '--print-input', action='store_true', help='print input cases if not AC')
+    subparser.add_argument('-j', '--jobs', type=int, help='run tests in parallel')
     subparser.add_argument('--no-ignore-backup', action='store_false', dest='ignore_backup')
     subparser.add_argument('--ignore-backup', action='store_true', help='ignore backup files and hidden files (i.e. files like "*~", "\\#*\\#" and ".*") (default)')
     subparser.add_argument('--json', action='store_true')

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -161,6 +161,7 @@ tips:
     subparser.add_argument('-f', '--format', default='%s.%e', help='a format string to recognize the relationship of test cases. (default: "%%s.%%e")')
     subparser.add_argument('-d', '--directory', type=pathlib.Path, default=pathlib.Path('test'), help='a directory name for test cases (default: test/)')
     subparser.add_argument('-t', '--tle', type=float, help='set the time limit (in second) (default: inf)')
+    subparser.add_argument('-j', '--jobs', type=int, help='run tests in parallel')
     subparser.add_argument('test', nargs='*', type=pathlib.Path, help='paths of input cases. (if empty: globbed from --format)')
     subparser.add_argument('--no-ignore-backup', action='store_false', dest='ignore_backup')
     subparser.add_argument('--ignore-backup', action='store_true', help='ignore backup files and hidden files (i.e. files like "*~", "\\#*\\#" and ".*") (default)')

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -141,7 +141,7 @@ tips:
     subparser.add_argument('-e', '--error', type=float, help='check as floating point number: correct if its absolute or relative error doesn\'t exceed it')
     subparser.add_argument('-t', '--tle', type=float, help='set the time limit (in second) (default: inf)')
     subparser.add_argument('-i', '--print-input', action='store_true', help='print input cases if not AC')
-    subparser.add_argument('-j', '--jobs', type=int, help='run tests in parallel')
+    subparser.add_argument('-j', '--jobs', metavar='N', type=int, help='specifies the number of jobs to run simultaneously  (default: no parallelization)')
     subparser.add_argument('--no-ignore-backup', action='store_false', dest='ignore_backup')
     subparser.add_argument('--ignore-backup', action='store_true', help='ignore backup files and hidden files (i.e. files like "*~", "\\#*\\#" and ".*") (default)')
     subparser.add_argument('--json', action='store_true')

--- a/tests/command_generate_output.py
+++ b/tests/command_generate_output.py
@@ -189,3 +189,31 @@ class GenerateOutputTest(unittest.TestCase):
                 },
             ],
         )
+
+    def test_call_generate_output_in_parallel(self):
+        input_files = []
+        expected_values = []
+        for i in range(1000):
+            name = 'sample-%03d' % i
+            input_files += [{
+                'path': 'test/{}.in'.format(name),
+                'data': str(i),
+            }]
+            if i > 950:
+                input_files += [{
+                    'path': 'test/{}.out'.format(name),
+                    'data': str(i),
+                }]
+            expected_values += [{
+                'path': 'test/{}.in'.format(name),
+                'data': str(i),
+            }]
+            expected_values += [{
+                'path': 'test/{}.out'.format(name),
+                'data': str(i),
+            }]
+        self.snippet_call_generate_output(
+            args=['--jobs', '256', '-c', 'bash -c "sleep 1 && cat"'],
+            input_files=input_files,
+            expected_values=expected_values,
+        )

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -17,7 +17,7 @@ class TestTest(unittest.TestCase):
             if 'output' in b['testcase']:
                 self.assertEqual(a['testcase']['output'], b['testcase']['output'] % result['tempdir'])
             self.assertEqual(a['exitcode'], b['exitcode'])
-            self.assertEqual(a['result'], b['result'])
+            self.assertEqual(a['status'], b['status'])
             self.assertEqual(a['output'], b['output'])
 
     def test_call_test_simple(self):
@@ -42,7 +42,7 @@ class TestTest(unittest.TestCase):
                 },
             ],
             expected=[{
-                'result': 'AC',
+                'status': 'AC',
                 'testcase': {
                     'name': 'sample-1',
                     'input': '%s/test/sample-1.in',
@@ -51,7 +51,7 @@ class TestTest(unittest.TestCase):
                 'output': 'foo\n',
                 'exitcode': 0,
             }, {
-                'result': 'WA',
+                'status': 'WA',
                 'testcase': {
                     'name': 'sample-2',
                     'input': '%s/test/sample-2.in',
@@ -92,7 +92,7 @@ class TestTest(unittest.TestCase):
                 },
             ],
             expected=[{
-                'result': 'AC',
+                'status': 'AC',
                 'testcase': {
                     'name': 'sample-2',
                     'input': '%s/test/sample-2.in',
@@ -100,7 +100,7 @@ class TestTest(unittest.TestCase):
                 'output': 'bar\n',
                 'exitcode': 0,
             }, {
-                'result': 'WA',
+                'status': 'WA',
                 'testcase': {
                     'name': 'sample-3',
                     'input': '%s/test/sample-3.in',
@@ -130,7 +130,7 @@ class TestTest(unittest.TestCase):
                 },
             ],
             expected=[{
-                'result': 'WA',
+                'status': 'WA',
                 'testcase': {
                     'name': 'sample-1',
                     'input': '%s/test/sample-1.in',
@@ -160,7 +160,7 @@ class TestTest(unittest.TestCase):
                 },
             ],
             expected=[{
-                'result': 'WA',
+                'status': 'WA',
                 'testcase': {
                     'name': 'sample-1',
                     'input': '%s/test/sample-1.in',
@@ -193,7 +193,7 @@ class TestTest(unittest.TestCase):
                 },
             ],
             expected=[{
-                'result': 'AC',
+                'status': 'AC',
                 'testcase': {
                     'name': 'sample-1',
                     'input': '%s/p/o/y/o/sample-1.in',
@@ -226,7 +226,7 @@ class TestTest(unittest.TestCase):
                 },
             ],
             expected=[{
-                'result': 'AC',
+                'status': 'AC',
                 'testcase': {
                     'name': 'sample-1.txt',
                     'input': '%s/yuki/coder/test_in/sample-1.txt',
@@ -267,7 +267,7 @@ class TestTest(unittest.TestCase):
                 },
             ],
             expected=[{
-                'result': 'AC',
+                'status': 'AC',
                 'testcase': {
                     'name': 'sample-2.txt',
                     'input': '%s/yuki/coder/test_in/sample-2.txt',
@@ -275,7 +275,7 @@ class TestTest(unittest.TestCase):
                 'output': 'bar\n',
                 'exitcode': 0,
             }, {
-                'result': 'AC',
+                'status': 'AC',
                 'testcase': {
                     'name': 'sample-3.txt',
                     'input': '%s/yuki/coder/test_in/sample-3.txt',
@@ -308,7 +308,7 @@ class TestTest(unittest.TestCase):
                 },
             ],
             expected=[{
-                'result': 'AC',
+                'status': 'AC',
                 'testcase': {
                     'name': 'sample.case.1',
                     'input': '%s/a/b/c/test_in/d/sample.case.1/e.case.txt',
@@ -317,7 +317,7 @@ class TestTest(unittest.TestCase):
                 'output': 'foo\n',
                 'exitcode': 0,
             }, {
-                'result': 'AC',
+                'status': 'AC',
                 'testcase': {
                     'name': 'sample.case.2',
                     'input': '%s/a/b/c/test_in/d/sample.case.2/e.case.txt',
@@ -350,7 +350,7 @@ class TestTest(unittest.TestCase):
                 },
             ],
             expected=[{
-                'result': 'AC',
+                'status': 'AC',
                 'testcase': {
                     'name': '1',
                     'input': '%s/a.*/[abc]/**/***/**/def/test_in/1.txt',

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -360,3 +360,32 @@ class TestTest(unittest.TestCase):
                 'exitcode': 0,
             }],
         )
+
+    def test_call_test_in_parallel(self):
+        files = []
+        expected = []
+        for i in range(1000):
+            name = 'sample-%03d' % i
+            files += [{
+                'path': 'test/{}.in'.format(name),
+                'data': '{}\n'.format(i),
+            }]
+            files += [{
+                'path': 'test/{}.out'.format(name),
+                'data': '{}\n'.format(i),
+            }]
+            expected += [{
+                'status': 'AC' if i == 1 else 'WA',
+                'testcase': {
+                    'name': name,
+                    'input': '%s/test/{}.in'.format(name),
+                    'output': '%s/test/{}.out'.format(name),
+                },
+                'output': '1\n',
+                'exitcode': 0,
+            }]
+        self.snippet_call_test(
+            args=['--jobs', '256', '--silent', '-c', 'bash -c "sleep 2 && echo 1"'],
+            files=files,
+            expected=expected,
+        )


### PR DESCRIPTION
close #428

テストを並列で実行できるようにします。
コンテスト中に「入力をランダムに生成して愚直解との不一致が現われるまで試し続ける」のような処理をする場合の利用を想定しています。

レビュー時の注意として:

-   元々のコードがそろそろ限界な感じだったのでリファクタリングのコミットもしています。
-   排他制御に気を付けてください。適当にやると異なるケースの出力が混ざって混乱するので、その回避のために `threading.Lock` を用いています。
-   標準エラー出力については特別な処理をせず、そのままターミナルに流す仕様です。

@fukatani :pray: