### PR TITLE
#437: fix a bug around --ignore-backup of test subcommand

### DIFF
--- a/onlinejudge/_implementation/format_utils.py
+++ b/onlinejudge/_implementation/format_utils.py
@@ -76,7 +76,7 @@ def path_from_format(directory: pathlib.Path, format: str, name: str, ext: str) 
 
 
 def is_backup_or_hidden_file(path: pathlib.Path) -> bool:
-    basename = path.stem
+    basename = path.name
     return basename.endswith('~') or (basename.startswith('#') and basename.endswith('#')) or basename.startswith('.')
 
 


### PR DESCRIPTION
close #437

https://github.com/kmyk/online-judge-tools/blob/49b2af11f6c4120dc79b7281e1837d82b9883296/onlinejudge/_implementation/format_utils.py#L78-L80

この `path.stem` が原因でした。これだと `/path/to/sample.in` のようなものに対し `sample` が返ってきてしまうので間違いで、 `path.name` が正解です。

テストも足しました。