### PR TITLE
#312: add a feature to check MLE

### DIFF
--- a/onlinejudge/_implementation/command/generate_output.py
+++ b/onlinejudge/_implementation/command/generate_output.py
@@ -25,9 +25,9 @@ def generate_output_single_case(test_name: str, test_input_path: pathlib.Path, *
 
     # run the command
     with test_input_path.open() as inf:
-        begin = time.perf_counter()
-        answer, proc = utils.exec_command(args.command, stdin=inf, timeout=args.tle)
-        end = time.perf_counter()
+        info, proc = utils.exec_command(args.command, stdin=inf, timeout=args.tle)
+        answer = info['answer']  # type: Optional[bytes]
+        elapsed = info['elapsed']  # type: float
 
     # acquire lock to print logs properly, if in parallel
     nullcontext = contextlib.ExitStack()
@@ -37,7 +37,7 @@ def generate_output_single_case(test_name: str, test_input_path: pathlib.Path, *
             log.info('%s', test_name)
 
         # check the result
-        log.status('time: %f sec', end - begin)
+        log.status('time: %f sec', elapsed)
         if proc.returncode is None:
             log.failure(log.red('TLE'))
             log.info('skipped.')
@@ -46,6 +46,7 @@ def generate_output_single_case(test_name: str, test_input_path: pathlib.Path, *
             log.failure(log.red('RE') + ': return code %d', proc.returncode)
             log.info('skipped.')
             return
+        assert answer is not None
         log.emit(utils.snip_large_file_content(answer, limit=40, head=20, tail=10, bold=True))
 
         # find the destination path

--- a/onlinejudge/_implementation/command/test.py
+++ b/onlinejudge/_implementation/command/test.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     import argparse
 
 MEMORY_WARNING = 500  # megabyte
+MEMORY_PRINT = 100  # megabyte
 
 
 def compare_as_floats(xs_: str, ys_: str, error: float) -> bool:
@@ -147,7 +148,10 @@ def test_single_case(test_name: str, test_input_path: pathlib.Path, test_output_
             log.info('%s', test_name)
         log.status('time: %f sec', elapsed)
         if memory:
-            if memory < MEMORY_WARNING:
+            if memory < MEMORY_PRINT:
+                if args.print_memory:
+                    log.status('memory: %f MB', memory)
+            elif memory < MEMORY_WARNING:
                 log.status('memory: %f MB', memory)
             else:
                 log.warning('memory: %f MB', memory)

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -142,7 +142,7 @@ tips:
     subparser.add_argument('-t', '--tle', type=float, help='set the time limit (in second) (default: inf)')
     subparser.add_argument('-i', '--print-input', action='store_true', help='print input cases if not AC')
     subparser.add_argument('-j', '--jobs', metavar='N', type=int, help='specifies the number of jobs to run simultaneously  (default: no parallelization)')
-    subparser.add_argument('--print-memory', action='store_true', help='print the amount of memory which your program used, even if it is enough small')
+    subparser.add_argument('--print-memory', action='store_true', help='print the amount of memory which your program used, even if it is small enough')
     subparser.add_argument('--gnu-time', help='used to measure memory consumption (default: "time")', default='time')
     subparser.add_argument('--no-ignore-backup', action='store_false', dest='ignore_backup')
     subparser.add_argument('--ignore-backup', action='store_true', help='ignore backup files and hidden files (i.e. files like "*~", "\\#*\\#" and ".*") (default)')

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -142,6 +142,7 @@ tips:
     subparser.add_argument('-t', '--tle', type=float, help='set the time limit (in second) (default: inf)')
     subparser.add_argument('-i', '--print-input', action='store_true', help='print input cases if not AC')
     subparser.add_argument('-j', '--jobs', metavar='N', type=int, help='specifies the number of jobs to run simultaneously  (default: no parallelization)')
+    subparser.add_argument('--print-memory', action='store_true', help='print the amount of memory which your program used, even if it is enough small')
     subparser.add_argument('--gnu-time', help='used to measure memory consumption (default: "time")', default='time')
     subparser.add_argument('--no-ignore-backup', action='store_false', dest='ignore_backup')
     subparser.add_argument('--ignore-backup', action='store_true', help='ignore backup files and hidden files (i.e. files like "*~", "\\#*\\#" and ".*") (default)')

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -142,6 +142,7 @@ tips:
     subparser.add_argument('-t', '--tle', type=float, help='set the time limit (in second) (default: inf)')
     subparser.add_argument('-i', '--print-input', action='store_true', help='print input cases if not AC')
     subparser.add_argument('-j', '--jobs', metavar='N', type=int, help='specifies the number of jobs to run simultaneously  (default: no parallelization)')
+    subparser.add_argument('--gnu-time', help='used to measure memory consumption (default: "time")', default='time')
     subparser.add_argument('--no-ignore-backup', action='store_false', dest='ignore_backup')
     subparser.add_argument('--ignore-backup', action='store_true', help='ignore backup files and hidden files (i.e. files like "*~", "\\#*\\#" and ".*") (default)')
     subparser.add_argument('--json', action='store_true')

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -455,3 +455,36 @@ class TestTest(unittest.TestCase):
             files=files,
             expected=expected,
         )
+
+    def test_call_test_large_memory(self):
+        # make a bytes of 100 MB
+        data = self.snippet_call_test(
+            args=['-c', """python -c 'print(len(b"A" * 100000000))'"""],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': 'foo\n'
+                },
+            ],
+            expected=None,
+        )
+        for case in data:
+            self.assertEqual(case['status'], 'AC')
+            self.assertGreater(case['memory'], 100)
+            self.assertLess(case['memory'], 1000)
+
+    def test_call_test_small_memory(self):
+        # just print "foo"
+        data = self.snippet_call_test(
+            args=['-c', """python -c 'print("foo")'"""],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': 'foo\n'
+                },
+            ],
+            expected=None,
+        )
+        for case in data:
+            self.assertEqual(case['status'], 'AC')
+            self.assertLess(case['memory'], 100)


### PR DESCRIPTION
close #312 

うっかり MLE しないようにメモリ使用量を監視する機能を足します。

具体的な仕様は次のようになります。

-   それぞれのテストケースで:
    -   メモリ使用量が 500MB より大きいなら目立たせて出力して警告
    -   メモリ使用量が 100MB より大きいならとりあえず出力
    -   メモリ使用量がそれ以下なら邪魔なので非表示 (オプションを指定で出力)
-   最後には常にメモリ使用量を出力 (同じ条件で必要なら目立たせて警告)

---

実装には GNU `time`  (`/usr/bin/time` とかにあるやつであって、shell builtin の `time` コマンドとは異なる) を利用しています。
メモリ使用量を監視するのは一般に面倒で (ある時刻の使用量でなくて実行開始から終了まででの全時刻の最大を取らないとだめ、監視対象のプロセスをきちんと指定しないとだめ、別プロセスのメモリ使用量を好き勝手に取得するのはセキュリティの問題がある)、 他のよい方法は思い付きませんでした。
もちろん `time` が常に存在するとは限らないですし、存在しても互換性の問題がないとも限らないので、とりあえず使ってみて動くかどうかを判断する処理も含んでいます。

@fukatani これもレビューが簡単ではないものですが、よろしくお願いします :bow: