### PR TITLE
#444: fix a bug of AtCoderContest.get_penalty()

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -251,7 +251,7 @@ class AtCoderContest(object):
         _, _, self._can_participate = soup.find('span', text=re.compile(r'^(Can Participate|参加対象): ')).text.partition(': ')
         _, _, self._rated_range = soup.find('span', text=re.compile(r'^(Rated Range|Rated対象): ')).text.partition(': ')
         penalty_text = soup.find('span', text=re.compile(r'^(Penalty|ペナルティ): ')).text
-        m = re.match(r'(Penalty|ペナルティ): (\d+)( minutes|分)', penalty_text)
+        m = re.match(r'(Penalty|ペナルティ): (\d+)( minutes?|分)', penalty_text)
         assert m
         self._penalty = datetime.timedelta(minutes=int(m.group(2)))
 

--- a/tests/service_atcoder.py
+++ b/tests/service_atcoder.py
@@ -59,6 +59,10 @@ class AtCoderContestTest(unittest.TestCase):
         self.assertEqual(contest.get_rated_range(), '-')
         self.assertEqual(contest.get_penalty().total_seconds(), 5 * 60)
 
+    def test_get_penalty_a_singular_form(self):
+        contest = AtCoderContest.from_url('https://atcoder.jp/contests/chokudai_S002')
+        self.assertEqual(contest.get_penalty().total_seconds(), 60)  # Penalty is written as "1 minute", not  "1 minutes"
+
     def test_list_problems(self):
         contest = AtCoderContest.from_url('https://atcoder.jp/contests/agc028')
         problems = contest.list_problems()


### PR DESCRIPTION
close #444

ペナルティの表記に `minute` の形があることを見落としていていました。これを修正します。