### PR TITLE
NONE: fix a bug of the memory checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 6.4.1 / 2019-06-18
+
+-   [#452](https://github.com/kmyk/online-judge-tools/pull/452) fix a bug of the MLE-checking and RE
+
 ## 6.4.0 / 2019-06-16
 
 -   [#438](https://github.com/kmyk/online-judge-tools/pull/438) update `setup.cfg` to make `oj.exe` in Windows environments

--- a/onlinejudge/__about__.py
+++ b/onlinejudge/__about__.py
@@ -4,6 +4,6 @@ __author__ = 'Kimiyuki Onaka'
 __email__ = 'kimiyuki95@gmail.com'
 __license__ = 'MIT License'
 __url__ = 'https://github.com/kmyk/online-judge-tools'
-__version_info__ = (6, 4, 0, 'final', 0)
+__version_info__ = (6, 4, 1, 'final', 0)
 __version__ = '.'.join(map(str, __version_info__[:3]))
 __description__ = 'Tools for online-judge services'

--- a/onlinejudge/_implementation/command/test.py
+++ b/onlinejudge/_implementation/command/test.py
@@ -178,11 +178,11 @@ def test_single_case(test_name: str, test_input_path: pathlib.Path, test_output_
 def check_gnu_time(gnu_time: str) -> bool:
     try:
         with tempfile.NamedTemporaryFile(delete=True) as fh:
-            proc = subprocess.run([gnu_time, '-f', '%M KB', '-o', fh.name, '--quiet', '--', 'true'])
+            proc = subprocess.run([gnu_time, '-f', '%M KB', '-o', fh.name, '--', 'true'])
             assert proc.returncode == 0
             with open(fh.name) as fh1:
                 data = fh1.read()
-            int(utils.remove_suffix(data.rstrip(), ' KB'))
+            int(utils.remove_suffix(data.rstrip().splitlines()[-1], ' KB'))
             return True
     except NameError:
         raise  # NameError is not a runtime error caused by the environmet, but a coding mistake

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -143,7 +143,7 @@ def exec_command(command_str: str, *, stdin: IO[Any], timeout: Optional[float] =
     with context as fh:
         command = shlex.split(command_str)
         if gnu_time is not None:
-            command = [gnu_time, '-f', '%M', '-o', fh.name, '--quiet', '--'] + command
+            command = [gnu_time, '-f', '%M', '-o', fh.name, '--'] + command
         begin = time.perf_counter()
 
         try:
@@ -163,7 +163,7 @@ def exec_command(command_str: str, *, stdin: IO[Any], timeout: Optional[float] =
         end = time.perf_counter()
         if gnu_time is not None:
             with open(fh.name) as fh1:
-                memory = int(fh1.read()) / 1000  # type: Optional[float]
+                memory = int(fh1.read().rstrip().splitlines()[-1]) / 1000  # type: Optional[float]
         else:
             memory = None
     info = {

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -488,3 +488,68 @@ class TestTest(unittest.TestCase):
         for case in data:
             self.assertEqual(case['status'], 'AC')
             self.assertLess(case['memory'], 100)
+
+    def test_call_stderr(self):
+        data = self.snippet_call_test(
+            args=['-c', """bash -c 'echo foo >&2'"""],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': 'foo\n'
+                },
+            ],
+            expected=[{
+                'status': 'AC',
+                'testcase': {
+                    'name': 'sample-1',
+                    'input': '%s/test/sample-1.in',
+                },
+                'output': '',
+                'exitcode': 0,
+            }],
+        )
+
+    def test_call_runtime_error(self):
+        data = self.snippet_call_test(
+            args=['-c', 'false'],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': 'foo\n'
+                },
+            ],
+            expected=[{
+                'status': 'RE',
+                'testcase': {
+                    'name': 'sample-1',
+                    'input': '%s/test/sample-1.in',
+                },
+                'output': '',
+                'exitcode': 1,
+            }],
+        )
+
+    def test_call_stderr_and_fail(self):
+        data = self.snippet_call_test(
+            args=['-c', """perl -e 'die "good bye"'"""],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': 'foo\n'
+                },
+                {
+                    'path': 'test/sample-1.out',
+                    'data': 'foo\n'
+                },
+            ],
+            expected=[{
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-1',
+                    'input': '%s/test/sample-1.in',
+                    'output': '%s/test/sample-1.out',
+                },
+                'output': '',
+                'exitcode': 255,
+            }],
+        )


### PR DESCRIPTION
`time` コマンドの呼び出したプログラムのリターンコードが非0だった場合にエラーになることに気付きました。次に示すような `Command exited with ...` という行が紛れ込んできて落ちます。これを修正します。

``` console
$ \time -f %M -- perl -e 'die "hoge"'
hoge at -e line 1.
Command exited with non-zero status 255
4840
```

``` console
$ oj t
[*] 3 cases found

[*] sample-1
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/debug/vector:417:
Error: attempt to subscript container with out-of-bounds index 7, but 
container only holds 7 elements.

Objects involved in the operation:
    sequence "this" @ 0x0x11adf88 {
      type = std::__debug::vector<int, std::allocator<int> >;
    }
Traceback (most recent call last):
  File "/home/user/.local/bin/oj", line 10, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.6/site-packages/onlinejudge/_implementation/main.py", line 284, in main
    run_program(namespace, parser=parser)
  File "/home/user/.local/lib/python3.6/site-packages/onlinejudge/_implementation/main.py", line 263, in run_program
    test(args)
  File "/home/user/.local/lib/python3.6/site-packages/onlinejudge/_implementation/command/test.py", line 213, in test
    history += [test_single_case(name, paths['in'], paths.get('out'), args=args)]
  File "/home/user/.local/lib/python3.6/site-packages/onlinejudge/_implementation/command/test.py", line 137, in test_single_case
    info, proc = utils.exec_command(args.command, stdin=inf, timeout=args.tle, gnu_time=args.gnu_time)
  File "/home/user/.local/lib/python3.6/site-packages/onlinejudge/_implementation/utils.py", line 166, in exec_command
    memory = int(fh1.read()) / 1000  # type: Optional[float]
ValueError: invalid literal for int() with base 10: 'Command terminated by signal 6\n3808\n'
```

@fukatani これは放置できないのでレビューを待たずにマージしてバージョンを上げます