### PR TITLE
#365: Catch HTTPError

### DIFF
--- a/onlinejudge/_implementation/command/download.py
+++ b/onlinejudge/_implementation/command/download.py
@@ -3,10 +3,7 @@ import json
 import os
 import pathlib
 import sys
-import traceback
 from typing import *
-
-import requests.exceptions
 
 import onlinejudge
 import onlinejudge._implementation.download_history
@@ -40,20 +37,11 @@ def download(args: 'argparse.Namespace') -> None:
         args.format = '%b.%e'
 
     # get samples from the server
-    try:
-        with utils.with_cookiejar(utils.new_session_with_our_user_agent(), path=args.cookie) as sess:
-            if args.system:
-                try:
-                    samples = problem.download_system_cases(session=sess)  # type: ignore
-                except onlinejudge.type.NotLoggedInError:
-                    log.error('login required')
-                    sys.exit(1)
-            else:
-                samples = problem.download_sample_cases(session=sess)  # type: ignore
-    except requests.exceptions.HTTPError as e:
-        log.error(str(e))
-        log.debug(traceback.format_exc())
-        sys.exit(1)
+    with utils.with_cookiejar(utils.new_session_with_our_user_agent(), path=args.cookie) as sess:
+        if args.system:
+            samples = problem.download_system_cases(session=sess)  # type: ignore
+        else:
+            samples = problem.download_sample_cases(session=sess)  # type: ignore
 
     # append the history for submit command
     if not args.dry_run and is_default_format:

--- a/onlinejudge/_implementation/command/download.py
+++ b/onlinejudge/_implementation/command/download.py
@@ -3,6 +3,7 @@ import json
 import os
 import pathlib
 import sys
+import traceback
 from typing import *
 
 import requests.exceptions
@@ -51,6 +52,7 @@ def download(args: 'argparse.Namespace') -> None:
                 samples = problem.download_sample_cases(session=sess)  # type: ignore
     except requests.exceptions.HTTPError as e:
         log.error(str(e))
+        log.debug(traceback.format_exc())
         sys.exit(1)
 
     # append the history for submit command

--- a/onlinejudge/_implementation/command/download.py
+++ b/onlinejudge/_implementation/command/download.py
@@ -1,13 +1,10 @@
 # Python Version: 3.x
-import datetime
 import json
 import os
 import pathlib
-import random
 import sys
 from typing import *
 
-import colorama
 import requests.exceptions
 
 import onlinejudge

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -6,6 +6,8 @@ import sys
 import traceback
 from typing import List, Optional
 
+import requests.exceptions
+
 import onlinejudge
 import onlinejudge.__about__ as version
 import onlinejudge._implementation.logging as log
@@ -254,7 +256,15 @@ def run_program(args: argparse.Namespace, parser: argparse.ArgumentParser) -> No
     log.debug('args: %s', str(args))
 
     if args.subcommand in ['download', 'd', 'dl']:
-        download(args)
+        try:
+            download(args)
+        except onlinejudge.type.NotLoggedInError:
+            log.error('login required')
+            sys.exit(1)
+        except requests.exceptions.HTTPError as e:
+            log.error(str(e))
+            log.debug(traceback.format_exc())
+            sys.exit(1)
     elif args.subcommand in ['login', 'l']:
         login(args)
     elif args.subcommand in ['submit', 's']:


### PR DESCRIPTION
before
```
$ oj download https://abc103.contest.atcoder.jp/tasks/abc103_
[x] problem recognized: AtCoderProblem.from_url('https://atcoder.jp/contests/abc103/tasks/abc103_'): https://abc103.contest.atcoder.jp/tasks/abc103_
[x] load cookie from: /home/ryo/.local/share/online-judge-tools/cookie.jar
[x] GET: https://atcoder.jp/contests/abc103/tasks/abc103_
[x] 404 Not Found
[!] AtCoder says: × Task not found.
[!] are you logged in?
Traceback (most recent call last):
  File "/home/ryo/workspace/github/chainer-wind-env/bin/oj", line 11, in <module>
    load_entry_point('online-judge-tools', 'console_scripts', 'oj')()
  File "/home/ryo/workspace/github/online-judge-tools/onlinejudge/_implementation/main.py", line 284, in main
    run_program(namespace, parser=parser)
  File "/home/ryo/workspace/github/online-judge-tools/onlinejudge/_implementation/main.py", line 257, in run_program
    download(args)
  File "/home/ryo/workspace/github/online-judge-tools/onlinejudge/_implementation/command/download.py", line 52, in download
    samples = problem.download_sample_cases(session=sess)  # type: ignore
  File "/home/ryo/workspace/github/online-judge-tools/onlinejudge/service/atcoder.py", line 593, in download_sample_cases
    return self.download_content(session=session).sample_cases
  File "/home/ryo/workspace/github/online-judge-tools/onlinejudge/service/atcoder.py", line 585, in download_content
    resp.raise_for_status()
  File "/home/ryo/workspace/github/chainer-wind-env/lib/python3.5/site-packages/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)

```

after
```
$ oj download https://abc103.contest.atcoder.jp/tasks/abc103_
[x] problem recognized: AtCoderProblem.from_url('https://atcoder.jp/contests/abc103/tasks/abc103_'): https://abc103.contest.atcoder.jp/tasks/abc103_
[x] load cookie from: /home/ryo/.local/share/online-judge-tools/cookie.jar
[x] GET: https://atcoder.jp/contests/abc103/tasks/abc103_
[x] 404 Not Found
[!] AtCoder says: × Task not found.
[!] are you logged in?
[ERROR] 404 Client Error: Not Found for url: https://atcoder.jp/contests/abc103/tasks/abc103_
```

エラーメッセージがコンパクトにはなった気がします。
よさそうなら他の例外もcatchします。

テストは、、どうしましょうねー :sweat: 