### PR TITLE
NONE: Add how to install development version oj

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,14 @@ The structure is as follows:
         -   ...
 -   `tests/`
 
+## install
+
+You can install online-judge-tools from your local directory with the following command.
+
+``` sh
+$ pip install -e .[dev,docs]
+```
+
 ## formatter
 
 We use `isort` adn `yapf`.


### PR DESCRIPTION
`pip install -e .`で開発中のonline-judge-toolsをインストールできるって説明を加えたほうがいいかなと思うのですが、どうでしょう？