### PR TITLE
RELEASE: 6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 6.5.0 / 2019-07-05
+
+-   [#456](https://github.com/kmyk/online-judge-tools/pull/456) support `download` samples from Facebook Hacker Cup
+-   [#453](https://github.com/kmyk/online-judge-tools/pull/453) make an error message better
+-   [#457](https://github.com/kmyk/online-judge-tools/pull/457) add tests about throwing exceptions
+
 ## 6.4.1 / 2019-06-18
 
 -   [#452](https://github.com/kmyk/online-judge-tools/pull/452) fix a bug of the MLE-checking and RE

--- a/docs/onlinejudge.service.facebook.rst
+++ b/docs/onlinejudge.service.facebook.rst
@@ -1,0 +1,7 @@
+onlinejudge.service.facebook module
+==================================
+
+.. automodule:: onlinejudge.service.facebook
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/onlinejudge.service.rst
+++ b/docs/onlinejudge.service.rst
@@ -11,6 +11,7 @@ Submodules
    onlinejudge.service.atcoder
    onlinejudge.service.codeforces
    onlinejudge.service.csacademy
+   onlinejudge.service.facebook
    onlinejudge.service.hackerrank
    onlinejudge.service.kattis
    onlinejudge.service.poj

--- a/onlinejudge/__about__.py
+++ b/onlinejudge/__about__.py
@@ -4,6 +4,6 @@ __author__ = 'Kimiyuki Onaka'
 __email__ = 'kimiyuki95@gmail.com'
 __license__ = 'MIT License'
 __url__ = 'https://github.com/kmyk/online-judge-tools'
-__version_info__ = (6, 4, 1, 'final', 0)
+__version_info__ = (6, 5, 0, 'final', 0)
 __version__ = '.'.join(map(str, __version_info__[:3]))
 __description__ = 'Tools for online-judge services'

--- a/onlinejudge/service/facebook.py
+++ b/onlinejudge/service/facebook.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """
 the module for Facebook Hacker Cup (https://www.facebook.com/hackercup/)
+
+.. versionadded:: 6.5.0
 """
 
 import urllib.parse


### PR DESCRIPTION
> ですね、461と460は少し後になっちゃいそうなので、今のmasterでバージョンを上げるのが良いと思います！

(https://gitter.im/online-judge-tools/community?at=5d1dfc3a84cbda1764cc4a65) ということだったので、バージョンを上げます。

---

@fukatani レビューと、よさそうならマージをお願いします。
PyPI の更新もついでにお願いします。マージしたらそのマージ後の `master` に `v6.5.0` という git tag を貼って GitHub へ反映させてください。 https://github.com/kmyk/online-judge-tools/blob/master/CONTRIBUTING.md#deployment の (2.) です。
ついでに Twitter での告知も (もしよければ) やってみてください。