### PR TITLE
#312: add --mle option for test subcommand

### DIFF
--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -143,6 +143,7 @@ tips:
     subparser.add_argument('-s', '--silent', action='store_true', help='don\'t report output and correct answer even if not AC  (for --mode all)')
     subparser.add_argument('-e', '--error', type=float, help='check as floating point number: correct if its absolute or relative error doesn\'t exceed it')
     subparser.add_argument('-t', '--tle', type=float, help='set the time limit (in second) (default: inf)')
+    subparser.add_argument('--mle', type=float, help='set the memory limit (in megabyte) (default: inf)')
     subparser.add_argument('-i', '--print-input', action='store_true', help='print input cases if not AC')
     subparser.add_argument('-j', '--jobs', metavar='N', type=int, help='specifies the number of jobs to run simultaneously  (default: no parallelization)')
     subparser.add_argument('--print-memory', action='store_true', help='print the amount of memory which your program used, even if it is small enough')

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -162,11 +162,13 @@ def exec_command(command_str: str, *, stdin: IO[Any], timeout: Optional[float] =
             answer = None
 
         end = time.perf_counter()
+        memory = None  # type: Optional[float]
         if gnu_time is not None:
             with open(fh.name) as fh1:
-                memory = int(fh1.read().splitlines()[-1]) / 1000  # type: Optional[float]
-        else:
-            memory = None
+                reported = fh1.read()
+            log.debug('GNU time says:\n%s', reported)
+            if reported.strip() and reported.splitlines()[-1].isdigit():
+                memory = int(reported.splitlines()[-1]) / 1000
     info = {
         'answer': answer,  # Optional[byte]
         'elapsed': end - begin,  # float, in second

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -472,6 +472,28 @@ class TestTest(unittest.TestCase):
             self.assertEqual(case['status'], 'AC')
             self.assertLess(case['memory'], 100)
 
+    @unittest.skipIf(os.name == 'nt', "memory checking is disabled on Windows environment")
+    def test_call_test_memory_limit_error(self):
+        # make a bytes of 100 MB
+        self.snippet_call_test(
+            args=['--mle', '50', '-c', tests.utils.python_c("print(len(b'A' * 100000000))")],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': 'foo\n'
+                },
+            ],
+            expected=[{
+                'status': 'MLE',
+                'testcase': {
+                    'name': 'sample-1',
+                    'input': '%s/test/sample-1.in',
+                },
+                'output': '100000000\n',
+                'exitcode': 0,
+            }],
+        )
+
     def test_call_stderr(self):
         data = self.snippet_call_test(
             args=['-c', tests.utils.python_c("import sys; print('foo', file=sys.stderr)")],

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -8,8 +8,8 @@ from tests.utils import cat
 
 
 class TestTest(unittest.TestCase):
-    def snippet_call_test(self, args, files, expected):
-        result = tests.utils.run_in_sandbox(args=['-v', 'test', '--json'] + args, files=files)
+    def snippet_call_test(self, args, files, expected, verbose=True):
+        result = tests.utils.run_in_sandbox(args=(['-v'] if verbose else []) + ['test', '--json'] + args, files=files)
         self.assertTrue(result['proc'].stdout)
         data = json.loads(result['proc'].stdout.decode())
         if expected is None:
@@ -434,6 +434,7 @@ class TestTest(unittest.TestCase):
             args=['--jobs', str(PARALLEL), '--silent', '-c', tests.utils.python_c("import time; time.sleep(1); print(1)")],
             files=files,
             expected=expected,
+            verbose=False,
         )
 
     @unittest.skipIf(os.name == 'nt', "memory checking is disabled on Windows environment")


### PR DESCRIPTION
#312 でやり残していた `--mle` オプションの追加をします。
わざわざ指定するのは面倒なので、この `oj` を直接利用するユーザにはあまり嬉しさはないのですが、上部の高品質な wrapper 経由で叩くユーザにとっては嬉しいはずです。