### PR TITLE
#459: enable the unit test to run for specified oj.exe

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,8 @@ environment:
   matrix:
     - PYTHON: C:\Python35
     - PYTHON: C:\Python36-x64
+    - PYTHON: C:\Python36-x64
+      TEST_OJ_EXE: dist\oj.exe  # for unit tests
 
 install:
   # Prepend newly installed Python to the PATH of this build (this cannot be

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,4 +41,4 @@ deploy:
   on:
     appveyor_repo_tag: true
     branch: master
-    PYTHON_VERSION: 3.6
+    TEST_OJ_EXE: dist\oj.exe

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,10 +34,19 @@ def sandbox(files):
             yield tempdir
 
 
-def run(args, *, env=None, check=False):
+def get_oj_exe():
+    oj_exe = os.environ.get('TEST_OJ_EXE')
+    if oj_exe is not None:
+        return [str(pathlib.Path(oj_exe).resolve())]
+    else:
+        return [sys.executable, '-m', 'onlinejudge._implementation.main']
+
+
+def run(args, *, env=None, check=False, oj_exe=get_oj_exe()):
+    # oj_exe should be evaluated out of sandboxes
     env = env or dict(os.environ)
     env['PYTHONPATH'] = str(pathlib.Path(__file__).parent.parent)  # this is required to run in sandboxes
-    return subprocess.run([sys.executable, '-m', 'onlinejudge._implementation.main'] + args, stdout=subprocess.PIPE, stderr=sys.stderr, env=env, check=check)
+    return subprocess.run(oj_exe + args, stdout=subprocess.PIPE, stderr=sys.stderr, env=env, check=check)
 
 
 def run_in_sandbox(args, files):


### PR DESCRIPTION
close #459 

`oj.exe` に対するテストを書きました。
これでテストが成功していることは https://github.com/kmyk/online-judge-tools/tree/feature/test-oj-exe-fail の https://github.com/kmyk/online-judge-tools/commit/a237aaad6783ccdd564ac65e1a56102c43d329ab が落ちていることから確認してください。