### PR TITLE
RELEASE: 6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 6.6.0 / 2019-07-15
+
+-   [#459](https://github.com/kmyk/online-judge-tools/issues/459) make and distribute portable executables for Windows
+-   [#470](https://github.com/kmyk/online-judge-tools/pull/470) add `--mle` option for `test` subcommand
+
 ## 6.5.0 / 2019-07-05
 
 -   [#456](https://github.com/kmyk/online-judge-tools/pull/456) support `download` samples from Facebook Hacker Cup

--- a/onlinejudge/__about__.py
+++ b/onlinejudge/__about__.py
@@ -4,6 +4,6 @@ __author__ = 'Kimiyuki Onaka'
 __email__ = 'kimiyuki95@gmail.com'
 __license__ = 'MIT License'
 __url__ = 'https://github.com/kmyk/online-judge-tools'
-__version_info__ = (6, 5, 0, 'final', 0)
+__version_info__ = (6, 6, 0, 'final', 0)
 __version__ = '.'.join(map(str, __version_info__[:3]))
 __description__ = 'Tools for online-judge services'


### PR DESCRIPTION
バージョンを上げます。
AppVeyor の deploy の設定の確認が目的です。

@fukatani マージしたら tag `v6.6.0` を打って GitHub に反映させてください。GitHub release や `oj.exe` のまわりが上手くいっていれば、Twitter での告知もお願いします。