### PR TITLE
NONE: replace "./test.sh" with "bash test.sh" in docs/run-ci-on-your-library.rst

### DIFF
--- a/docs/run-ci-on-your-library.rst
+++ b/docs/run-ci-on-your-library.rst
@@ -98,7 +98,7 @@ Travis CI のページ https://travis-ci.org/ から登録してライブラリ�
        - pip3 install -U setuptools
        - pip3 install -U online-judge-tools=='6.*'
    script:
-       - ./test.sh
+       - bash test.sh
 
 
 自動で実行されたテスト結果は Travis CI 上のページ (例: https://travis-ci.org/kmyk/competitive-programming-library) などから見ることができます。


### PR DESCRIPTION
ちょっとだけ修正です。
`./test.sh` だと実行可能フラグ立てないとだめなのでユーザに優しくない。しかし実行可能フラグの概念の説明をするのもしんどい。なので単に `bash test.sh` に修正します。