### PR TITLE
NONE: make it possible to install with old setuptools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,6 @@ $ pip3 install online-judge-tools
 ```
 
 It requires Python 3.5 or later.
-It also requires `setuptools` 30.3.0 or later for `setup.cfg`.
 
 ### from this repository
 
@@ -178,7 +177,7 @@ AtCoder Beginner Contest 118: B - Foods Loved by Everyone    kotatsugame  (37 by
 ## FAQ
 
 -   I cannot install this tool. How should I do?
-    -   Check versions of your Python and `setuptools`. Also consider the use of Windows Subsystem for Linux (WSL) if you use Windows environment.
+    -   Check versions of your Python. Also consider the use of Windows Subsystem for Linux (WSL) if you use Windows environment.
 -   Are there features to manage templates or snippets?
     -   No. They are not the responsibility of this tool. You should use plugins of your editor, like [thinca/vim-template](https://github.com/thinca/vim-template) or [Shougo/deoplete.nvim](https://github.com/Shougo/deoplete.nvim).
 -   I usually make one directory per one contest (or, site). Is there a support for this style?

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,24 +14,6 @@ classifiers =
     Topic :: Text Processing :: Markup :: HTML
     Topic :: Utilities
 
-[options]
-install_requires =
-    appdirs >= 1
-    beautifulsoup4 >= 4
-    colorama >= 0.3
-    lxml >= 4
-    requests >= 2
-packages = find:
-
-[options.entry_points]
-console_scripts =
-    oj = onlinejudge._implementation.main:main
-
-[options.packages.find]
-exclude =
-    tests
-    docs
-
 [options.extras_require]
 dev =
     isort >= 4.3.4

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,7 @@
 import imp
 import os
 
-import setuptools
-from pkg_resources import parse_version
-from setuptools import setup
-
-if parse_version(setuptools.__version__) < parse_version('30.3.0'):
-    raise RuntimeError('setuptools>=30.3.0 is required for "setup.cfg"')
+from setuptools import find_packages, setup
 
 
 def load_module(module_path):
@@ -28,4 +23,17 @@ setup(
     url=version.__url__,
     license=version.__license__,
     description=version.__description__,
+    install_requires=[
+        'appdirs >= 1',
+        'beautifulsoup4 >= 4',
+        'colorama >= 0.3',
+        'lxml >= 4',
+        'requests >= 2',
+    ],
+    packages=find_packages(exclude=('tests', 'docs')),
+    entry_poitns={
+        'console_scripts': [
+            'oj = onlinejudge._implementation.main:main',
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'requests >= 2',
     ],
     packages=find_packages(exclude=('tests', 'docs')),
-    entry_poitns={
+    entry_points={
         'console_scripts': [
             'oj = onlinejudge._implementation.main:main',
         ],


### PR DESCRIPTION
`setup.cfg` は新しめ (といっても数年前) の `setuptools` を要求してしまう問題があります。しかたがないので最低限の部分だけを `setup.py` に書き戻します。