### PR TITLE
#468: reduce the number of jobs on tests of -j options

### DIFF
--- a/tests/command_generate_output.py
+++ b/tests/command_generate_output.py
@@ -189,8 +189,8 @@ class GenerateOutputTest(unittest.TestCase):
         )
 
     def test_call_generate_output_in_parallel(self):
-        TOTAL = 1000
-        PARALLEL = 256
+        TOTAL = 100
+        PARALLEL = 32
         input_files = []
         expected_values = []
         for i in range(TOTAL):

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -402,8 +402,8 @@ class TestTest(unittest.TestCase):
         )
 
     def test_call_test_in_parallel(self):
-        TOTAL = 1000
-        PARALLEL = 256
+        TOTAL = 100
+        PARALLEL = 32
         files = []
         expected = []
         for i in range(TOTAL):


### PR DESCRIPTION
Windows 環境上での並列実行の問題 #468 がありましたが、やっぱりまだときどき落ちるので対策します。