### PR TITLE
NONE: skip tests for POJ if poj.org is down

### DIFF
--- a/tests/command_download_poj.py
+++ b/tests/command_download_poj.py
@@ -2,8 +2,17 @@ import unittest
 
 import tests.command_download
 
+import onlinejudge._implementation.utils as utils
+
 
 class DownloadPOJTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        session = utils.get_default_session()
+        resp = utils.request('GET', 'http://poj.org/', session)
+        if resp.status_code != 200:
+            raise unittest.SkipTest('poj.org is down now')
+
     def snippet_call_download(self, *args, **kwargs):
         tests.command_download.snippet_call_download(self, *args, **kwargs)
 


### PR DESCRIPTION
http://poj.org/ はよく落ちるのですが、これが落ちてる間ずっと CI も落ちてしまうのは適切ではありません。これをなんとかします。