### PR TITLE
NONE: supress a noisy log of parsing samples of AtCoder

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -666,7 +666,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
             if lang is None:
                 lang = l
             elif lang != l:
-                log.info('skipped due to language: current one is %s, not %s: %s ', lang, l, name)
+                log.debug('skipped due to language: current one is %s, not %s: %s ', lang, l, name)
                 continue
             samples.add(s.encode(), name)
         return samples.get()


### PR DESCRIPTION
AtCoder のページは日本語の問題文と英語の問題文を両方持っていて、片方を不可視 (HTML 的には存在する) にしています。サンプルもそれに応じてすべて 2 回ずつ出現しています。
これに関連しての警告のようなメッセージを出力していたのですが、どうにも邪魔な気がするため消しておきます。