### PR TITLE
Handle empty testcases for AtCoder (e.g. AGC036 B)

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -638,7 +638,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
         for pre in soup.find_all('pre'):
             log.debug('pre tag: %s', str(pre))
             if not pre.string:
-                continue
+                pre.string = ''
 
             def h3_plus(tag):
                 prv = tag.find_previous_sibling()


### PR DESCRIPTION
I changed the behavior that `oj download` ignores empty testcases.
Such a testcase is found at [AGC036 B](https://atcoder.jp/contests/agc036/tasks/agc036_b).

This fix is only for AtCoder. It might be better to change implementations for other contests.