### PR TITLE
#515: make "python3 steup.py test" always succeed

### DIFF
--- a/tests/command_download_yukicoder.py
+++ b/tests/command_download_yukicoder.py
@@ -1,7 +1,8 @@
-import os
 import unittest
 
 import tests.command_download
+
+from onlinejudge.service.yukicoder import YukicoderService
 
 
 class DownloadYukicoderTest(unittest.TestCase):
@@ -18,7 +19,7 @@ class DownloadYukicoderTest(unittest.TestCase):
             'sample-1.out': '3bb50ff8eeb7ad116724b56a820139fa',
         })
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(YukicoderService()), 'login is required')
     def test_call_download_yukicoder_no_8_system(self):
         self.snippet_call_download('https://yukicoder.me/problems/no/8', {
             '01.txt.in': '04e90eb0c4a65eefa084dfea8e89de9f',

--- a/tests/command_login.py
+++ b/tests/command_login.py
@@ -1,15 +1,20 @@
-import os
 import unittest
 
 import tests.utils
+
+from onlinejudge.service.atcoder import AtCoderService
+from onlinejudge.service.codeforces import CodeforcesService
+from onlinejudge.service.hackerrank import HackerRankService
+from onlinejudge.service.topcoder import TopcoderService
+from onlinejudge.service.toph import TophService
+from onlinejudge.service.yukicoder import YukicoderService
 
 
 class LoginTest(unittest.TestCase):
     def snippet_call_login_check_failure(self, url):
         with tests.utils.sandbox(files=[]) as tempdir:
-            env = dict(**os.environ)
-            env['HOME'] = tempdir
-            proc = tests.utils.run(['login', '--check', url], env=env)
+            path = 'cookie.jar'  # use dummy cookie to check in an empty state
+            proc = tests.utils.run(['--cookie', path, 'login', '--check', url])
             self.assertEqual(proc.returncode, 1)
 
     def snippet_call_login_check_success(self, url):
@@ -33,26 +38,26 @@ class LoginTest(unittest.TestCase):
     def test_call_login_check_yukicoder_failure(self):
         self.snippet_call_login_check_failure('https://yukicoder.me/')
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(AtCoderService()), 'login is required')
     def test_call_login_check_atcoder_success(self):
         self.snippet_call_login_check_success('https://atcoder.jp/')
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(CodeforcesService()), 'login is required')
     def test_call_login_check_codeforces_success(self):
         self.snippet_call_login_check_success('https://codeforces.com/')
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(HackerRankService()), 'login is required')
     def test_call_login_check_hackerrank_success(self):
         self.snippet_call_login_check_success('https://www.hackerrank.com/')
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(TopcoderService()), 'login is required')
     def test_call_login_check_topcoder_success(self):
         self.snippet_call_login_check_success('https://community.topcoder.com/')
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(TophService()), 'login is required')
     def test_call_login_check_toph_success(self):
         self.snippet_call_login_check_success('https://toph.co/')
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(YukicoderService()), 'login is required')
     def test_call_login_check_yukicoder_success(self):
         self.snippet_call_login_check_success('https://yukicoder.me/')

--- a/tests/command_submit.py
+++ b/tests/command_submit.py
@@ -1,4 +1,3 @@
-import os
 import time
 import unittest
 
@@ -7,10 +6,15 @@ import tests.utils
 
 from onlinejudge._implementation.command.submit import submit
 from onlinejudge._implementation.main import get_parser
+from onlinejudge.service.atcoder import AtCoderService
+from onlinejudge.service.codeforces import CodeforcesService
+from onlinejudge.service.hackerrank import HackerRankService
+from onlinejudge.service.toph import TophService
+from onlinejudge.service.yukicoder import YukicoderService
 
 
 class SubmitArgumentsTest(unittest.TestCase):
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(AtCoderService()), 'login is required')
     def test_call_submit_atcoder_practice_1_with_history(self):
 
         url = 'https://atcoder.jp/contests/practice/tasks/practice_1'
@@ -24,7 +28,7 @@ class SubmitArgumentsTest(unittest.TestCase):
             tests.utils.run(['dl', url], check=True)
             tests.utils.run(['s', '-y', '--no-open', 'a.pl'], check=True)
 
-    @unittest.skipIf('CI' in os.environ or os.name == 'nt', 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(AtCoderService()), 'login is required')
     def test_call_submit_atcoder_practice_1_with_open(self):
 
         url = 'https://atcoder.jp/contests/practice/tasks/practice_1'
@@ -40,7 +44,7 @@ class SubmitArgumentsTest(unittest.TestCase):
                 url = fh.read().strip()
             self.assertTrue(url.startswith('https://atcoder.jp/contests/practice/submissions/'))
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(AtCoderService()), 'login is required')
     def test_call_submit_atcoder_invalid_url(self):
 
         url = 'https://atcoder.jp/contests/practice/tasks/practice_111'
@@ -70,7 +74,7 @@ class SubmitArgumentsTest(unittest.TestCase):
 
 
 class SubmitAtCoderTest(unittest.TestCase):
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(AtCoderService()), 'login is required')
     def test_call_submit_practice_1(self):
 
         url = 'https://atcoder.jp/contests/practice/tasks/practice_1'
@@ -95,7 +99,7 @@ int main() {
         with tests.utils.sandbox(files):
             tests.utils.run(['submit', '-y', '--no-open', url, 'main.cpp'], check=True)
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(AtCoderService()), 'login is required')
     def test_call_submit_practice_2(self):
 
         url = 'https://atcoder.jp/contests/practice/tasks/practice_2'
@@ -132,7 +136,7 @@ print('!', ''.join(quick_sort(string.ascii_uppercase[: n])))
 
 
 class SubmitCodeforcesTest(unittest.TestCase):
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(CodeforcesService()), 'login is required')
     def test_call_submit_beta_1_a(self):
 
         url = 'https://codeforces.com/contest/1/problem/A'
@@ -151,7 +155,7 @@ class SubmitCodeforcesTest(unittest.TestCase):
         with tests.utils.sandbox(files):
             tests.utils.run(['s', '-y', '--no-open', url, 'a.py'], check=True)
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(CodeforcesService()), 'login is required')
     def test_call_submit_beta_3_b(self):
 
         url = 'https://codeforces.com/contest/3/problem/B'
@@ -226,7 +230,7 @@ int main() {
 
 
 class SubmitYukicoderTest(unittest.TestCase):
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(YukicoderService()), 'login is required')
     def test_call_submit_9000(self):
 
         url = 'https://yukicoder.me/problems/no/9000'
@@ -243,7 +247,7 @@ class SubmitYukicoderTest(unittest.TestCase):
         with tests.utils.sandbox(files):
             tests.utils.run(['s', '-y', '--no-open', url, 'a.py'], check=True)
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(YukicoderService()), 'login is required')
     def test_call_submit_beta_3_b(self):
 
         url = 'https://yukicoder.me/problems/527'
@@ -267,7 +271,7 @@ int main() {
 
 
 class SubmitHackerRankTest(unittest.TestCase):
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(HackerRankService()), 'login is required')
     def test_call_submit_worldcodesprint_mars_exploration(self):
         url = 'https://www.hackerrank.com/contests/worldcodesprint/challenges/mars-exploration'
         code = '''#!/usr/bin/env python3
@@ -293,7 +297,7 @@ print(ans)
 
 
 class SubmitTophTest(unittest.TestCase):
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(TophService()), 'login is required')
     def test_call_submit_copycat(self):
         url = 'https://toph.co/p/copycat'
         code = '''#!/usr/bin/env python3
@@ -309,7 +313,7 @@ print(s)
         with tests.utils.sandbox(files):
             tests.utils.run(['s', '-l', '58482c1804469e2585024324', '-y', '--no-open', url, 'a.py'], check=True)
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(TophService()), 'login is required')
     def test_call_submit_divisors(self):
         url = 'https://toph.co/p/divisors'
         code = '''#include<bits/stdc++.h>

--- a/tests/service_topcoder.py
+++ b/tests/service_topcoder.py
@@ -1,5 +1,6 @@
-import os
 import unittest
+
+import tests.utils
 
 import onlinejudge._implementation.utils as utils
 from onlinejudge.service.topcoder import TopcoderLongContestProblem, TopcoderService
@@ -51,7 +52,7 @@ class TopcoderLongConrestProblemTest(unittest.TestCase):
         self.assertEqual(len(feed.submissions), 5)
         self.assertEqual(len(feed.testcases), 2000)
 
-    @unittest.skipIf('CI' in os.environ, 'login is required')
+    @unittest.skipIf(not tests.utils.is_logged_in(TopcoderService()), 'login is required')
     def test_download_system_test(self):
         with utils.with_cookiejar(utils.get_default_session()):
             url = 'https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=17143&pm=14889'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -73,3 +73,12 @@ def python_c(cmd):
 def python_script(path):
     assert '"' not in path
     return '{} "{}"'.format(sys.executable, path)
+
+
+def is_logged_in(service, memo={}):
+    # functools.lru_cache is unusable since Service are unhashable
+    url = service.get_url()
+    if url not in memo:
+        proc = run(['login', '--check', url])
+        memo[url] = proc.returncode == 0
+    return memo[url]


### PR DESCRIPTION
close #515 
ログインが必要なテストはログイン済みの場合にのみ実行するようにします。これでローカルでもテストは常に成功するようになります。