### PR TITLE
#514: fix a problem of WebDriver on Windows

### DIFF
--- a/onlinejudge/_implementation/command/login.py
+++ b/onlinejudge/_implementation/command/login.py
@@ -55,7 +55,7 @@ def login_with_browser(service: onlinejudge.type.Service, *, session: requests.S
         while driver.current_url:
             cookies = driver.get_cookies()
             time.sleep(0.1)
-    except selenium.common.exceptions.NoSuchWindowException:
+    except selenium.common.exceptions.WebDriverException:
         pass  # the window is closed
 
     # set cookies to the requests.Session


### PR DESCRIPTION
close #514 
もともと例外を catch することでウィンドウが閉じられたことを確認していましたが、 Windows 環境下では飛ぶ例外の種類が異なるようです。最も広く受けられる例外クラスを指定すれば解決するので、そのようにします。