### PR TITLE
#519: use webbrowser module instead of sensible-browser command

### DIFF
--- a/onlinejudge/_implementation/command/submit.py
+++ b/onlinejudge/_implementation/command/submit.py
@@ -1,12 +1,9 @@
 # Python Version: 3.x
-import os
 import pathlib
 import re
-import shlex
-import shutil
-import subprocess
 import sys
 import time
+import webbrowser
 from typing import *
 
 import onlinejudge
@@ -17,8 +14,6 @@ from onlinejudge.type import *
 
 if TYPE_CHECKING:
     import argparse
-
-default_url_opener = ['sensible-browser', 'xdg-open', 'open']
 
 
 def submit(args: 'argparse.Namespace') -> None:
@@ -146,22 +141,11 @@ def submit(args: 'argparse.Namespace') -> None:
 
         # show result
         if args.open:
-            if args.open_browser:
-                browser = args.open_browser
-            else:
-                for browser in default_url_opener:
-                    if shutil.which(browser):
-                        break
-                else:
-                    browser = None
-                    log.failure('couldn\'t find browsers to open the url. please specify a browser')
-            if browser:
-                log.status('open the submission page with: %s', browser)
-                if os.name == 'nt':
-                    command = [browser, submission.get_url()]
-                else:
-                    command = shlex.split(browser) + [submission.get_url()]
-                subprocess.check_call(command, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
+            browser = webbrowser.get()
+            log.status('open the submission page with: %s', browser.name)
+            opened = browser.open_new_tab(submission.get_url())
+            if not opened:
+                log.failure('failed to open the url. please set the $BROWSER envvar')
 
 
 def select_ids_of_matched_languages(words: List[str], lang_ids: List[str], language_dict, split: bool = False, remove: bool = False) -> List[str]:

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -114,7 +114,6 @@ supported services:
     subparser.add_argument('-G', '--golf', action='store_true', help='now equivalent to --format-dos2unix --format-rstrip')
     subparser.add_argument('--no-open', action='store_false', dest='open')
     subparser.add_argument('--open', action='store_true', default=True, help='open the result page after submission (default)')
-    subparser.add_argument('--open-browser')
     subparser.add_argument('-w', '--wait', metavar='SECOND', type=float, default=3, help='sleep before submitting')
     subparser.add_argument('-y', '--yes', action='store_true', help='don\'t confirm')
     subparser.add_argument('--full-submission', action='store_true', help='for Topcoder Marathon Match. use this to do "Submit", the default behavier is "Test Examples".')


### PR DESCRIPTION
close #519

`sensible-browser` command とかのあたりを頑張って叩いていたのをやめ、`webbrowser` module を使います。コードが簡潔になり、かつ、WIndows 環境への可搬性が向上します。

-   `--open-browser` option を削除する破壊的変更が含まれています。
-   ブラウザを新規に起動する形になってしまったときに `oj` のプロセスをブロックしてしまう問題 (仕様) はそのままです。