### PR TITLE
None: fix contributing.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,8 +117,6 @@ $ python3 setup.py test
 $ python3 setup.py test -s tests.command_download_atcoder.DownloadAtCoderTest
 ```
 
-なお `python3 setup.py test` は formatter が利用されているかの確認もするように設定されています。
-
 ## CI
 
 Travis CI will run automatically when you commit or send PR on `master` or `develop` branch.


### PR DESCRIPTION
pytest時間かかるかもなので、これはこれで入れます。
シンプルに消しました。
上で言うとおりformatterをかけてくれれば、ローカルでチェックする必要はないと思うので。
(チェックコマンドを叩くくらいなら、formatterを叩くべき。)