### PR TITLE
#539: let the CI example show an error message if oj doesn't exist

### DIFF
--- a/docs/run-ci-on-your-library.rst
+++ b/docs/run-ci-on-your-library.rst
@@ -27,7 +27,7 @@ online-judge-tools には、ライブラリのテストに利用できる機能�
 
    #!/bin/bash
    set -e
-   which oj > /dev/null
+   oj --version
 
    CXX=${CXX:-g++}
    CXXFLAGS="${CXXFLAGS:--std=c++14 -O2 -Wall -g}"


### PR DESCRIPTION
fix #539 
cc: @yosupo06

The problem described in #539 is almost a bug, so it should be fixed.
`test.sh` with this patch says `test.sh: line 3: oj: command not found` if `oj` doesn't exist.

``` console
$ bash test.sh
test.sh: line 3: oj: command not found
```

Note: We can print some error message explicitly (e.g. `which oj || { echo "ERROR MESSAGE" ; exit 1 ; }`), but I think this way is too redundant and not good for the purpose of an example.