### PR TITLE
Increase command test coverage.

### DIFF
--- a/onlinejudge/_implementation/command/test.py
+++ b/onlinejudge/_implementation/command/test.py
@@ -188,7 +188,7 @@ def check_gnu_time(gnu_time: str) -> bool:
             int(utils.remove_suffix(data.rstrip().splitlines()[-1], ' KB'))
             return True
     except NameError:
-        raise  # NameError is not a runtime error caused by the environmet, but a coding mistake
+        raise  # NameError is not a runtime error caused by the environment, but a coding mistake
     except AttributeError:
         raise  # AttributeError is also a mistake
     except Exception as e:

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -146,6 +146,14 @@ class TestTest(unittest.TestCase):
                     'path': 'test/sample-4.out',
                     'data': 'bar\n'
                 },
+                {
+                    'path': 'test/sample-5.in',
+                    'data': '1.0\n2.0\n'.replace('\n', os.linesep)
+                },
+                {
+                    'path': 'test/sample-5.out',
+                    'data': '1.0\n'.replace('\n', os.linesep)
+                },
             ],
             expected=[{
                 'status': 'AC',
@@ -182,6 +190,15 @@ class TestTest(unittest.TestCase):
                     'output': '%s/test/sample-4.out',
                 },
                 'output': 'foo\n',
+                'exitcode': 0,
+            }, {
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-5',
+                    'input': '%s/test/sample-5.in',
+                    'output': '%s/test/sample-5.out',
+                },
+                'output': '1.0\n2.0\n'.replace('\n', os.linesep),
                 'exitcode': 0,
             }],
         )

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -130,6 +130,22 @@ class TestTest(unittest.TestCase):
                     'path': 'test/sample-2.out',
                     'data': '1.2\n'
                 },
+                {
+                    'path': 'test/sample-3.in',
+                    'data': 'foo\n'
+                },
+                {
+                    'path': 'test/sample-3.out',
+                    'data': 'foo\n'
+                },
+                {
+                    'path': 'test/sample-4.in',
+                    'data': 'foo\n'
+                },
+                {
+                    'path': 'test/sample-4.out',
+                    'data': 'bar\n'
+                },
             ],
             expected=[{
                 'status': 'AC',
@@ -148,6 +164,24 @@ class TestTest(unittest.TestCase):
                     'output': '%s/test/sample-2.out',
                 },
                 'output': '1.0\n',
+                'exitcode': 0,
+            }, {
+                'status': 'AC',
+                'testcase': {
+                    'name': 'sample-3',
+                    'input': '%s/test/sample-3.in',
+                    'output': '%s/test/sample-3.out',
+                },
+                'output': 'foo\n',
+                'exitcode': 0,
+            }, {
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-4',
+                    'input': '%s/test/sample-4.in',
+                    'output': '%s/test/sample-4.out',
+                },
+                'output': 'foo\n',
                 'exitcode': 0,
             }],
         )

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -273,6 +273,14 @@ class TestTest(unittest.TestCase):
                     'path': 'test/sample-3.out',
                     'data': 'bar\nfoobar\nbar\n'
                 },
+                {
+                    'path': 'test/sample-4.in',
+                    'data': 'bar\nfoobar\nbar\n'
+                },
+                {
+                    'path': 'test/sample-4.out',
+                    'data': 'bar\nfoobar\n'
+                },
             ],
             expected=[{
                 'status': 'AC',
@@ -300,6 +308,15 @@ class TestTest(unittest.TestCase):
                     'output': '%s/test/sample-3.out',
                 },
                 'output': 'bar\nfoobar\n',
+                'exitcode': 0,
+            }, {
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-4',
+                    'input': '%s/test/sample-4.in',
+                    'output': '%s/test/sample-4.out',
+                },
+                'output': 'bar\nfoobar\nbar\n',
                 'exitcode': 0,
             }],
         )

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -265,6 +265,14 @@ class TestTest(unittest.TestCase):
                     'path': 'test/sample-2.out',
                     'data': 'bar\nbarbar\n'
                 },
+                {
+                    'path': 'test/sample-3.in',
+                    'data': 'bar\nfoobar\n'
+                },
+                {
+                    'path': 'test/sample-3.out',
+                    'data': 'bar\nfoobar\nbar\n'
+                },
             ],
             expected=[{
                 'status': 'AC',
@@ -281,6 +289,15 @@ class TestTest(unittest.TestCase):
                     'name': 'sample-2',
                     'input': '%s/test/sample-2.in',
                     'output': '%s/test/sample-2.out',
+                },
+                'output': 'bar\nfoobar\n',
+                'exitcode': 0,
+            }, {
+                'status': 'WA',
+                'testcase': {
+                    'name': 'sample-3',
+                    'input': '%s/test/sample-3.in',
+                    'output': '%s/test/sample-3.out',
                 },
                 'output': 'bar\nfoobar\n',
                 'exitcode': 0,


### PR DESCRIPTION
これで`test.py`の入れてない重要な分岐はなくなるはず、、
残りは例外やログ表示など。入れないところもありますし後回しでいいでしょう。