### PR TITLE
#535: Pinning version of linter libraries.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,10 +18,10 @@ classifiers =
 selenium =
     selenium >= 3.141.0
 dev =
-    isort >= 4.3.4
-    mypy >= 0.660
-    pylint >= 2.3.1
-    yapf >= 0.28.0
+    isort == 4.3.21
+    mypy == 0.740
+    pylint == 2.4.3
+    yapf == 0.28.0
     pytest >= 5.1.2
     pytest-cov >= 2.7.1
 docs =


### PR DESCRIPTION
Resolve #535 .
For build stability, these library version should be pinned.
But we should not forget update them regularly.
Especially, many of `mypy` updates are helpful for finding bugs.