### PR TITLE
None: type of fix list_problems.

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -365,9 +365,8 @@ class AtCoderContest(onlinejudge.type.Contest):
         tbody = soup.find('tbody')
         return [AtCoderProblemData._from_table_row(tr, session=session, response=resp, timestamp=timestamp) for tr in tbody.find_all('tr')]
 
-    # TODO: why does this require "type: ignore"?
-    def list_problems(self, *, session: Optional[requests.Session] = None) -> 'List[AtCoderProblem]':  # type: ignore
-        return [data.problem for data in self.list_problem_data(session=session)]
+    def list_problems(self, *, session: Optional[requests.Session] = None) -> Sequence['AtCoderProblem']:
+        return tuple([data.problem for data in self.list_problem_data(session=session)])
 
     # yapf: disable
     def iterate_submission_data_where(

--- a/onlinejudge/service/codeforces.py
+++ b/onlinejudge/service/codeforces.py
@@ -207,9 +207,8 @@ class CodeforcesContest(onlinejudge.type.Contest):
         assert data['status'] == 'OK'
         return [CodeforcesProblemData._from_json(row, response=resp, session=session, timestamp=timestamp) for row in data['result']['problems']]
 
-    # TODO: why is "type: ignore" required?
-    def list_problems(self, *, session: Optional[requests.Session] = None) -> List['CodeforcesProblem']:  # type: ignore
-        return [data.problem for data in self.list_problem_data(session=session)]
+    def list_problems(self, *, session: Optional[requests.Session] = None) -> Sequence['CodeforcesProblem']:
+        return tuple([data.problem for data in self.list_problem_data(session=session)])
 
     def download_data(self, *, session: Optional[requests.Session] = None) -> CodeforcesContestData:
         session = session or utils.get_default_session()

--- a/onlinejudge/type.py
+++ b/onlinejudge/type.py
@@ -8,7 +8,7 @@ the module containing base types
 
 import datetime
 from abc import ABC, abstractmethod
-from typing import Callable, Iterator, List, NamedTuple, NewType, Optional, Tuple
+from typing import Callable, Iterator, List, NamedTuple, NewType, Optional, Sequence, Tuple
 
 import requests
 
@@ -173,7 +173,7 @@ class Contest(ABC):
 
     .. versionadded:: 7.0.0
     """
-    def list_problems(self, *, session: Optional[requests.Session] = None) -> List['Problem']:
+    def list_problems(self, *, session: Optional[requests.Session] = None) -> Sequence['Problem']:
         raise NotImplementedError
 
     def download_data(self, *, session: Optional[requests.Session] = None) -> ContestData:


### PR DESCRIPTION
https://github.com/python/mypy/issues/2984

のjukkaLさんの発言を元に修正。

結局immutableなコレクションだったらいいようで、`Sequence[SubClass]`だったら通ります。

疑問
- Sequence[Problem]といいつつ実装でリストを返してもmypyがエラーを発しない。(mypyの限界？)
- なんでimmutableなコレクションだったら問題ないのかよくわかってない(私の理解力の問題)。

とはいえ、mypyのコラボレーターが言ってることだし、immutableであればいいということでタプルを返すようにしました。

他にもListを返している関数がありますが、それの要素は継承関係がないしということでそのままにしています。
また、`list_problems`という関数名もひとまずそのままにしています。