### PR TITLE
#553: fix the parsing problem in <pre> tag

### DIFF
--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -51,10 +51,13 @@ def next_sibling_tag(tag: bs4.Tag) -> bs4.Tag:
 
 
 # remove all HTML tag without interpretation (except <br>)
+# remove all comment
 # using DFS(Depth First Search)
-def parse_content(parent: Union[bs4.NavigableString, bs4.Tag]) -> bs4.NavigableString:
+def parse_content(parent: Union[bs4.NavigableString, bs4.Tag, bs4.Comment]) -> bs4.NavigableString:
     res = ''
-    if isinstance(parent, bs4.NavigableString):
+    if isinstance(parent, bs4.Comment):
+        pass
+    elif isinstance(parent, bs4.NavigableString):
         return parent
     else:
         children = parent.contents

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -8,7 +8,6 @@ import http.cookiejar
 import json
 import os
 import pathlib
-import posixpath
 import shlex
 import shutil
 import subprocess
@@ -21,6 +20,7 @@ from typing.io import *
 
 import appdirs
 import bs4
+import posixpath
 
 import onlinejudge.__about__ as version
 import onlinejudge._implementation.logging as log

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -53,6 +53,7 @@ def next_sibling_tag(tag: bs4.Tag) -> bs4.Tag:
 # remove all HTML tag without interpretation (except <br>)
 # remove all comment
 # using DFS(Depth First Search)
+# discussed in https://github.com/kmyk/online-judge-tools/issues/553
 def parse_content(parent: Union[bs4.NavigableString, bs4.Tag, bs4.Comment]) -> bs4.NavigableString:
     res = ''
     if isinstance(parent, bs4.Comment):

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -50,6 +50,23 @@ def next_sibling_tag(tag: bs4.Tag) -> bs4.Tag:
     return tag
 
 
+# remove all HTML tag without interpretation (except <br>)
+# using DFS(Depth First Search)
+def parse_content(parent: Union[bs4.NavigableString, bs4.Tag]) -> bs4.NavigableString:
+    res = ''
+    if isinstance(parent, bs4.NavigableString):
+        return parent
+    else:
+        children = parent.contents
+        if len(children) == 0:
+            html_tag = str(parent)
+            return bs4.NavigableString('\n') if 'br' in html_tag else bs4.NavigableString('')
+        else:
+            for child in children:
+                res += parse_content(child)
+    return bs4.NavigableString(res)
+
+
 def new_session_with_our_user_agent() -> requests.Session:
     session = requests.Session()
     session.headers['User-Agent'] += ' (+{})'.format(version.__url__)

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -8,6 +8,7 @@ import http.cookiejar
 import json
 import os
 import pathlib
+import posixpath
 import shlex
 import shutil
 import subprocess
@@ -20,7 +21,6 @@ from typing.io import *
 
 import appdirs
 import bs4
-import posixpath
 
 import onlinejudge.__about__ as version
 import onlinejudge._implementation.logging as log

--- a/onlinejudge/service/yukicoder.py
+++ b/onlinejudge/service/yukicoder.py
@@ -7,11 +7,11 @@ the module for yukicoder (https://yukicoder.me/)
 """
 
 import json
+import posixpath
 import urllib.parse
 from typing import *
 
 import bs4
-import posixpath
 
 import onlinejudge._implementation.logging as log
 import onlinejudge._implementation.testcase_zipper

--- a/onlinejudge/service/yukicoder.py
+++ b/onlinejudge/service/yukicoder.py
@@ -255,7 +255,7 @@ class YukicoderProblem(onlinejudge.type.Problem):
                 data, name = it
                 samples.add(data.encode(), name)
         return samples.get()
-    
+
     def get_handmade_sample_cases(self, *, html: str) -> List[TestCase]:
         # parse
         soup = bs4.BeautifulSoup(html, utils.html_parser)
@@ -267,7 +267,6 @@ class YukicoderProblem(onlinejudge.type.Problem):
                 data, name = it
                 samples.add(data.encode(), name)
         return samples.get()
-
 
     def download_system_cases(self, *, session: Optional[requests.Session] = None) -> List[TestCase]:
         """
@@ -371,7 +370,7 @@ class YukicoderProblem(onlinejudge.type.Problem):
                     return cls(problem_id=int(n))
             return cls()
         return None
-    
+
     @classmethod
     def from_nothing(cls) -> Optional['YukicoderProblem']:
         # to test handmade sample cases (like https://github.com/kmyk/online-judge-tools/issues/553)

--- a/onlinejudge/service/yukicoder.py
+++ b/onlinejudge/service/yukicoder.py
@@ -7,11 +7,11 @@ the module for yukicoder (https://yukicoder.me/)
 """
 
 import json
-import posixpath
 import urllib.parse
 from typing import *
 
 import bs4
+import posixpath
 
 import onlinejudge._implementation.logging as log
 import onlinejudge._implementation.testcase_zipper

--- a/onlinejudge/service/yukicoder.py
+++ b/onlinejudge/service/yukicoder.py
@@ -256,18 +256,6 @@ class YukicoderProblem(onlinejudge.type.Problem):
                 samples.add(data.encode(), name)
         return samples.get()
 
-    def get_handmade_sample_cases(self, *, html: str) -> List[TestCase]:
-        # parse
-        soup = bs4.BeautifulSoup(html, utils.html_parser)
-        samples = onlinejudge._implementation.testcase_zipper.SampleZipper()
-        for pre in soup.select('.sample pre'):
-            log.debug('pre %s', str(pre))
-            it = self._parse_sample_tag(pre)
-            if it is not None:
-                data, name = it
-                samples.add(data.encode(), name)
-        return samples.get()
-
     def download_system_cases(self, *, session: Optional[requests.Session] = None) -> List[TestCase]:
         """
         :raises NotLoggedInError:
@@ -370,12 +358,6 @@ class YukicoderProblem(onlinejudge.type.Problem):
                     return cls(problem_id=int(n))
             return cls()
         return None
-
-    @classmethod
-    def from_nothing(cls) -> Optional['YukicoderProblem']:
-        # to test handmade sample cases (like https://github.com/kmyk/online-judge-tools/issues/553)
-        n = -1
-        return cls(problem_no=int(n))
 
     def get_service(self) -> YukicoderService:
         return YukicoderService()

--- a/tests/implementation_utils.py
+++ b/tests/implementation_utils.py
@@ -1,0 +1,19 @@
+import bs4
+
+import onlinejudge._implementation.logging as log
+import onlinejudge._implementation.testcase_zipper
+import onlinejudge._implementation.utils as utils
+from onlinejudge.type import *
+
+
+def get_handmade_sample_cases(self, *, html: str) -> List[TestCase]:
+    # parse
+    soup = bs4.BeautifulSoup(html, utils.html_parser)
+    samples = onlinejudge._implementation.testcase_zipper.SampleZipper()
+    for pre in soup.select('.sample pre'):
+        log.debug('pre %s', str(pre))
+        it = self._parse_sample_tag(pre)
+        if it is not None:
+            data, name = it
+            samples.add(data.encode(), name)
+    return samples.get()

--- a/tests/service_yukicoder.py
+++ b/tests/service_yukicoder.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import unittest
 
+from tests.utils import get_handmade_sample_cases
+
 from onlinejudge.service.yukicoder import YukicoderProblem, YukicoderService
 from onlinejudge.type import *
 
@@ -98,14 +100,25 @@ class YukicoderProblemTest(unittest.TestCase):
             <pre><i><strong>We<br/><mark>Love</mark><br/><s>Competitive</s><br/>Programming!</strong></i></pre>
         </div>
     </div>
+
+    <div class="sample">
+        <h5 class="underline">サンプル4</h5>
+        <div class="paragraph">
+            <h6>入力</h6>
+            <pre></pre>
+            <h6>出力</h6>
+            <pre>A<-- comment1 -->B<!-- comment2 -->C</pre>
+        </div>
+    </div>
 </div>
 </body>
 </html>
 """
-        self.assertEqual(YukicoderProblem.from_nothing().get_handmade_sample_cases(html=handmade_html), [
+        self.assertEqual(get_handmade_sample_cases(YukicoderProblem(problem_no=5555), html=handmade_html), [
             TestCase(name='sample-1', input_name='サンプル1 入力', input_data=b'3\n1 2\n3 4\n5 6\n', output_name='サンプル1 出力', output_data=b'0\n\n\n\n\n0\n'),
             TestCase(name='sample-2', input_name='サンプル2 入力', input_data=b'1 1 1\n1 0 1\n1 1 1\n', output_name='サンプル2 出力', output_data=b'0\n'),
             TestCase(name='sample-3', input_name='サンプル3 入力', input_data=b'\n', output_name='サンプル3 出力', output_data=b'We\nLove\nCompetitive\nProgramming!\n'),
+            TestCase(name='sample-4', input_name='サンプル4 入力', input_data=b'\n', output_name='サンプル4 出力', output_data=b'ABC\n'),
         ])
 
 

--- a/tests/service_yukicoder.py
+++ b/tests/service_yukicoder.py
@@ -57,6 +57,56 @@ class YukicoderProblemTest(unittest.TestCase):
             TestCase(name='sample-1', input_name='サンプル1 入力', input_data=b'3\n1 8 3\n2\n6 10\n', output_name='サンプル1 出力', output_data=b'5 72\n'),
             TestCase(name='sample-2', input_name='サンプル2 入力', input_data=b'2\n-1 1\n3\n-1 1 -1\n', output_name='サンプル2 出力', output_data=b'-1 1\n'),
         ])
+    
+    def test_download_handmade_cases_issue_553(self):
+        # see https://github.com/kmyk/online-judge-tools/issues/553
+        handmade_html = """
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+</head>
+<body>
+<div class="block">
+    <div class="sample">
+        <h5 class="underline">サンプル1</h5>
+        <div class="paragraph">
+            <h6>入力</h6>
+            <pre><strong>3<br/>1</strong> 2<br/>3 4<br/>5 6</pre>
+            <h6>出力</h6>
+            <pre>0<br/><br/><br/><br/><br/>0</pre>
+        </div>
+    </div>
+
+    <div class="sample">
+        <h5 class="underline">サンプル2</h5>
+        <div class="paragraph">
+            <h6>入力</h6>
+            <pre>1 1 1
+1 <strong><mark>0</mark></strong> 1
+1 1 1</pre>
+            <h6>出力</h6>
+            <pre><s>0</s></pre>
+        </div>
+    </div>
+
+    <div class="sample">
+        <h5 class="underline">サンプル3</h5>
+        <div class="paragraph">
+            <h6>入力</h6>
+            <pre><i></i></pre>
+            <h6>出力</h6>
+            <pre><i><strong>We<br/><mark>Love</mark><br/><s>Competitive</s><br/>Programming!</strong></i></pre>
+        </div>
+    </div>
+</div>
+</body>
+</html>
+"""
+        self.assertEqual(YukicoderProblem.from_nothing().get_handmade_sample_cases(html=handmade_html), [
+            TestCase(name='sample-1', input_name='サンプル1 入力', input_data=b'3\n1 2\n3 4\n5 6\n', output_name='サンプル1 出力', output_data=b'0\n\n\n\n\n0\n'),
+            TestCase(name='sample-2', input_name='サンプル2 入力', input_data=b'1 1 1\n1 0 1\n1 1 1\n', output_name='サンプル2 出力', output_data=b'0\n'),
+            TestCase(name='sample-3', input_name='サンプル3 入力', input_data=b'\n', output_name='サンプル3 出力', output_data=b'We\nLove\nCompetitive\nProgramming!\n'),
+        ])
 
 
 class YukicoderOfficialAPITest(unittest.TestCase):

--- a/tests/service_yukicoder.py
+++ b/tests/service_yukicoder.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from tests.utils import get_handmade_sample_cases
+from tests.implementation_utils import get_handmade_sample_cases
 
 from onlinejudge.service.yukicoder import YukicoderProblem, YukicoderService
 from onlinejudge.type import *

--- a/tests/service_yukicoder.py
+++ b/tests/service_yukicoder.py
@@ -58,7 +58,7 @@ class YukicoderProblemTest(unittest.TestCase):
             TestCase(name='sample-2', input_name='サンプル2 入力', input_data=b'2\n-1 1\n3\n-1 1 -1\n', output_name='サンプル2 出力', output_data=b'-1 1\n'),
         ])
 
-    def test_download_handmade_cases_issue_553(self):
+    def test_get_handmade_cases_issue_553(self):
         # see https://github.com/kmyk/online-judge-tools/issues/553
         handmade_html = """
 <!DOCTYPE html>

--- a/tests/service_yukicoder.py
+++ b/tests/service_yukicoder.py
@@ -57,7 +57,7 @@ class YukicoderProblemTest(unittest.TestCase):
             TestCase(name='sample-1', input_name='サンプル1 入力', input_data=b'3\n1 8 3\n2\n6 10\n', output_name='サンプル1 出力', output_data=b'5 72\n'),
             TestCase(name='sample-2', input_name='サンプル2 入力', input_data=b'2\n-1 1\n3\n-1 1 -1\n', output_name='サンプル2 出力', output_data=b'-1 1\n'),
         ])
-    
+
     def test_download_handmade_cases_issue_553(self):
         # see https://github.com/kmyk/online-judge-tools/issues/553
         handmade_html = """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,14 @@ import pathlib
 import subprocess
 import sys
 import tempfile
+from typing import *
+
+import bs4
+
+import onlinejudge._implementation.logging as log
+import onlinejudge._implementation.testcase_zipper
+import onlinejudge._implementation.utils as utils
+from onlinejudge.type import *
 
 
 @contextlib.contextmanager
@@ -89,3 +97,16 @@ def is_logged_in(service, memo={}):
         proc = run(['login', '--check', url])
         memo[url] = proc.returncode == 0
     return memo[url]
+
+
+def get_handmade_sample_cases(self, *, html: str) -> List[TestCase]:
+    # parse
+    soup = bs4.BeautifulSoup(html, utils.html_parser)
+    samples = onlinejudge._implementation.testcase_zipper.SampleZipper()
+    for pre in soup.select('.sample pre'):
+        log.debug('pre %s', str(pre))
+        it = self._parse_sample_tag(pre)
+        if it is not None:
+            data, name = it
+            samples.add(data.encode(), name)
+    return samples.get()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,14 +4,6 @@ import pathlib
 import subprocess
 import sys
 import tempfile
-from typing import *
-
-import bs4
-
-import onlinejudge._implementation.logging as log
-import onlinejudge._implementation.testcase_zipper
-import onlinejudge._implementation.utils as utils
-from onlinejudge.type import *
 
 
 @contextlib.contextmanager
@@ -97,16 +89,3 @@ def is_logged_in(service, memo={}):
         proc = run(['login', '--check', url])
         memo[url] = proc.returncode == 0
     return memo[url]
-
-
-def get_handmade_sample_cases(self, *, html: str) -> List[TestCase]:
-    # parse
-    soup = bs4.BeautifulSoup(html, utils.html_parser)
-    samples = onlinejudge._implementation.testcase_zipper.SampleZipper()
-    for pre in soup.select('.sample pre'):
-        log.debug('pre %s', str(pre))
-        it = self._parse_sample_tag(pre)
-        if it is not None:
-            data, name = it
-            samples.add(data.encode(), name)
-    return samples.get()


### PR DESCRIPTION
In #553, I described our tools couldn't parse sample cases such as `<pre><strong>3<br/>1</strong> 2<br/>3 4<br/>5 6</pre>` correctly. In this pull request, I try to solve this problem.
<br/>
<img src="https://i.imgur.com/AimBPec.png" alt="issue-553"/>
<br/>
Let me introduce the image above.

The image above is a rooted tree which root is a sample (input || output) we want to treat correctly.
In this image, each node is painted by type.
- red ... `bs4.Tag`
- blue ... `bs4.NavigableString`

The root type is always `bs4.Tag` (because every input for online-judge-tools is surrounded by`<pre></pre>`).  

`bs4.Tag` has attribute `.contents` (`bs4.NavigableString` and `bs4.Comment` doesn't).

If we use `.contents` to variable which type is `bs4.Tag`, then we get `list` which elements' type is `bs4.Tag` or `bs4.NavigableString` or `bs4.Comment`.

(`<br/>` type is `bs4.Tag` and when we use `.contents` to it, then we get empty list.)

So, if we get a sample (input || output), we get a rooted tree in finite step.  

Previously, I have used `.strings` to solve parsing problems (#552) but it is not flexible enough to our needs.

To solve this, I have implemented `parse_content` function in onlinejudge/_implementation/utils.py and call it in other parse function.

<br/>
<br/>
<br/>

By the way, it seems that there are no inputs we are now arguing in the real environment now.
So, I add some function to do test.

But I'm not confident of my implementation about test. If it isn't stylish, I want your help for improvement.

<br/>
<br/>

Any comments && clarifications are welcome!