### PR TITLE
fix CHANGELOG.md with adding contributors' names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 # 7.2.2 / 2019-10-23
 
--   [#561](https://github.com/kmyk/online-judge-tools/pull/561) fix a potential bug of yukicoder problems
--   [#560](https://github.com/kmyk/online-judge-tools/pull/560) fix a bug of Codeforces.list_problems
+-   [#561](https://github.com/kmyk/online-judge-tools/pull/561) fix a potential bug of yukicoder problems ([@kawacchu](https://github.com/kawacchu))
+-   [#560](https://github.com/kmyk/online-judge-tools/pull/560) fix a bug of `CodeforceContest.list_problems`
+-   [#562](https://github.com/kmyk/online-judge-tools/pull/562) add [the English translation](https://online-judge-tools.readthedocs.io/en/master/introduction.en.html) of introduction document ([@pieceofeden](https://github.com/pieceofeden))
+-   [#567](https://github.com/kmyk/online-judge-tools/pull/567) improve English of `readme.md` ([@nishanth2143](https://github.com/nishanth2143))
 
 # 7.2.1 / 2019-10-18
 


### PR DESCRIPTION
`CHANGELOG.md` に漏れていた変更やコントリビュータの名前を追加します。

まじめに見てなかったので見逃がしていました。ドキュメントの追加は CHANGELOG に乗せる価値があるものですし、コントリビュータの名前も書かれる必要があります。
特にコントリビュータの名前を乗せるのは重要です。それが readme に書き切れなくなったとしても CHANGELOG には書いていくべきです。誰がどの部分にどれだけ貢献したかの情報を明確にすることは OSS 開発にとって重要です。
詳細については https://producingoss.com/ja/credit.html や https://keepachangelog.com/ja/1.0.0/#why を読んでみてください。