### PR TITLE
[breaking consistency] Unsupport --overwrite option and abort download if file already exists.

### DIFF
--- a/onlinejudge/_implementation/command/download.py
+++ b/onlinejudge/_implementation/command/download.py
@@ -2,8 +2,9 @@
 import json
 import os
 import pathlib
-import sys
 from typing import *
+
+import requests.exceptions
 
 import onlinejudge
 import onlinejudge._implementation.download_history
@@ -29,7 +30,7 @@ def download(args: 'argparse.Namespace') -> None:
     # prepare values
     problem = onlinejudge.dispatch.problem_from_url(args.url)
     if problem is None:
-        sys.exit(1)
+        raise requests.exceptions.InvalidURL('The contest "%s" is not supported' % args.url)
     is_default_format = args.format is None and args.directory is None  # must be here since args.directory and args.format are overwritten
     if args.directory is None:
         args.directory = pathlib.Path('test')

--- a/onlinejudge/_implementation/command/download.py
+++ b/onlinejudge/_implementation/command/download.py
@@ -71,9 +71,6 @@ def download(args: 'argparse.Namespace') -> None:
                 continue
             if path.exists():
                 log.warning('file already exists: %s', path)
-                if not args.overwrite:
-                    log.warning('skipped')
-                    continue
             path.parent.mkdir(parents=True, exist_ok=True)
             with path.open('wb') as fh:
                 fh.write(data)

--- a/onlinejudge/_implementation/command/download.py
+++ b/onlinejudge/_implementation/command/download.py
@@ -70,7 +70,7 @@ def download(args: 'argparse.Namespace') -> None:
             if args.dry_run:
                 continue
             if path.exists():
-                log.warning('file already exists: %s', path)
+                raise FileExistsError('Failed to download since file already exists: ' + str(path))
             path.parent.mkdir(parents=True, exist_ok=True)
             with path.open('wb') as fh:
                 fh.write(data)

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -68,7 +68,6 @@ format string for --format:
     subparser.add_argument('url')
     subparser.add_argument('-f', '--format', help='a format string to specify paths of cases (default: "sample-%%i.%%e" if not --system)')  # default must be None for --system
     subparser.add_argument('-d', '--directory', type=pathlib.Path, help='a directory name for test cases (default: test/)')  # default must be None for guessing in submit command
-    subparser.add_argument('--overwrite', action='store_true')
     subparser.add_argument('-n', '--dry-run', action='store_true', help='don\'t write to files')
     subparser.add_argument('-a', '--system', action='store_true', help='download system testcases')
     subparser.add_argument('-s', '--silent', action='store_true')

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -310,6 +310,9 @@ def main(args: Optional[List[str]] = None) -> None:
     except onlinejudge.type.SampleParseError:
         log.error('Failed to parse sample.')
         sys.exit(1)
+    except FileExistsError as e:
+        log.error(str(e))
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -307,6 +307,9 @@ def main(args: Optional[List[str]] = None) -> None:
         log.error(str(e))
         log.debug(traceback.format_exc())
         sys.exit(1)
+    except requests.exceptions.InvalidURL as e:
+        log.error(str(e))
+        sys.exit(1)
     except onlinejudge.type.SampleParseError:
         log.error('Failed to parse sample.')
         sys.exit(1)

--- a/tests/command_download_invalid.py
+++ b/tests/command_download_invalid.py
@@ -8,5 +8,24 @@ class DownloadInvalid(unittest.TestCase):
     def snippet_call_download_raises(self, *args, **kwargs):
         tests.command_download.snippet_call_download_raises(self, *args, **kwargs)
 
+    def snippet_call_download_twice(self, *args, **kwargs):
+        tests.command_download.snippet_call_download_twice(self, *args, **kwargs)
+
     def test_call_download_invalid(self):
         self.snippet_call_download_raises(requests.exceptions.InvalidURL, 'https://not_exist_contest.jp/tasks/001_a')
+
+    def test_call_download_twice(self):
+        self.snippet_call_download_twice('https://atcoder.jp/contests/abc114/tasks/abc114_c', 'https://atcoder.jp/contests/abc003/tasks/abc003_4', [
+            {
+                "input": "575\n",
+                "output": "4\n"
+            },
+            {
+                "input": "3600\n",
+                "output": "13\n"
+            },
+            {
+                "input": "999999999\n",
+                "output": "26484\n"
+            },
+        ], type='json')

--- a/tests/command_download_invalid.py
+++ b/tests/command_download_invalid.py
@@ -1,0 +1,12 @@
+import unittest
+
+import requests.exceptions
+import tests.command_download
+
+
+class DownloadInvalid(unittest.TestCase):
+    def snippet_call_download_raises(self, *args, **kwargs):
+        tests.command_download.snippet_call_download_raises(self, *args, **kwargs)
+
+    def test_call_download_invalid(self):
+        self.snippet_call_download_raises(requests.exceptions.InvalidURL, 'https://not_exist_contest.jp/tasks/001_a')


### PR DESCRIPTION
- remove `--overwrite` option
- abort `download` if file already exists.
- raise InvalidURL if contest is not supported. (Sorry, this feature can be split to other PR)
