### PR TITLE
[breaking minor API] replace get_problem of submissions with download_problem

### DIFF
--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -370,7 +370,7 @@ class DummySubmission(Submission):
     def get_url(self) -> str:
         return self.url
 
-    def download_problem(self) -> Problem:
+    def download_problem(self, *, session: Optional[requests.Session] = None) -> Problem:
         raise NotImplementedError
 
     def get_service(self) -> Service:

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -370,8 +370,8 @@ class DummySubmission(Submission):
     def get_url(self) -> str:
         return self.url
 
-    def get_problem(self) -> Problem:
-        return self.problem
+    def download_problem(self) -> Problem:
+        raise NotImplementedError
 
     def get_service(self) -> Service:
         raise NotImplementedError

--- a/onlinejudge/dispatch.py
+++ b/onlinejudge/dispatch.py
@@ -54,12 +54,6 @@ def problem_from_url(url: str) -> Optional[Problem]:
         if problem is not None:
             log.status('problem recognized: %s: %s', str(problem), url)
             return problem
-    submission = submission_from_url(url)
-    if submission is not None:
-        try:
-            return submission.download_problem()
-        except NotImplementedError:
-            pass
     log.failure('unknown problem: %s', url)
     return None
 

--- a/onlinejudge/dispatch.py
+++ b/onlinejudge/dispatch.py
@@ -56,7 +56,10 @@ def problem_from_url(url: str) -> Optional[Problem]:
             return problem
     submission = submission_from_url(url)
     if submission is not None:
-        return submission.get_problem()
+        try:
+            return submission.download_problem()
+        except NotImplementedError:
+            pass
     log.failure('unknown problem: %s', url)
     return None
 

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -1099,13 +1099,6 @@ class AtCoderSubmission(onlinejudge.type.Submission):
         problem_id = self.download_data(session=session).problem_id
         return AtCoderProblem(contest_id=self.contest_id, problem_id=problem_id)
 
-    def get_problem(self) -> AtCoderProblem:
-        """
-        :raises Exception:
-        :note: There is no way to reconstruct problem_id without networking
-        """
-        raise Exception
-
     def download_data(self, *, session: Optional[requests.Session] = None) -> AtCoderSubmissionDetailedData:
         """
         :note: `Exec Time` is undefined when the status is `RE` or `TLE`

--- a/onlinejudge/type.py
+++ b/onlinejudge/type.py
@@ -343,10 +343,6 @@ class Submission(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_problem(self) -> Problem:
-        raise NotImplementedError
-
-    @abstractmethod
     def download_problem(self) -> Problem:
         raise NotImplementedError
 

--- a/onlinejudge/type.py
+++ b/onlinejudge/type.py
@@ -310,14 +310,6 @@ class SubmissionData(DownloadedData):
         raise NotImplementedError
 
     @property
-    def problem(self) -> Problem:
-        return self.submission.get_problem()
-
-    @property
-    def contest(self) -> Contest:
-        return self.submission.get_contest()
-
-    @property
     def service(self) -> Service:
         return self.submission.get_service()
 
@@ -346,12 +338,9 @@ class Submission(ABC):
     def download_problem(self) -> Problem:
         raise NotImplementedError
 
-    def get_contest(self) -> Contest:
-        return self.get_problem().get_contest()
-
     @abstractmethod
     def get_service(self) -> Service:
-        return self.get_problem().get_service()
+        raise NotImplementedError
 
     def __repr__(self) -> str:
         return '{}.from_url({})'.format(self.__class__.__name__, repr(self.get_url()))

--- a/onlinejudge/type.py
+++ b/onlinejudge/type.py
@@ -335,7 +335,7 @@ class Submission(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def download_problem(self) -> Problem:
+    def download_problem(self, *, session: Optional[requests.Session] = None) -> Problem:
         raise NotImplementedError
 
     @abstractmethod

--- a/onlinejudge/type.py
+++ b/onlinejudge/type.py
@@ -346,6 +346,10 @@ class Submission(ABC):
     def get_problem(self) -> Problem:
         raise NotImplementedError
 
+    @abstractmethod
+    def download_problem(self) -> Problem:
+        raise NotImplementedError
+
     def get_contest(self) -> Contest:
         return self.get_problem().get_contest()
 

--- a/onlinejudge/type.py
+++ b/onlinejudge/type.py
@@ -338,6 +338,9 @@ class Submission(ABC):
     def download_problem(self, *, session: Optional[requests.Session] = None) -> Problem:
         raise NotImplementedError
 
+    def download_contest(self) -> Contest:
+        return self.download_problem().get_contest()
+
     @abstractmethod
     def get_service(self) -> Service:
         raise NotImplementedError

--- a/tests/dispatch.py
+++ b/tests/dispatch.py
@@ -13,6 +13,11 @@ class DispatchAtCoderTest(unittest.TestCase):
         self.assertEqual(problem.download_input_format(), '\r\n<var>N</var>\r\n<var>c_1c_2c_3…c_N</var>\r\n')
         self.assertEqual(problem.get_name(), 'センター採点')
 
+    def test_problem_from_url_via_submission(self):
+        problem = dispatch.problem_from_url('https://atcoder.jp/contests/abc143/submissions/8059168')
+        self.assertTrue(isinstance(problem, service.atcoder.AtCoderProblem))
+        self.assertEqual(problem.get_url(), 'https://atcoder.jp/contests/abc143/tasks/abc143_c')
+
     def test_submission_from_url(self):
         submission = dispatch.submission_from_url('https://atcoder.jp/contests/agc039/submissions/7874055')
         self.assertIsInstance(submission, service.atcoder.AtCoderSubmission)

--- a/tests/dispatch.py
+++ b/tests/dispatch.py
@@ -22,8 +22,6 @@ class DispatchAtCoderTest(unittest.TestCase):
         submission = dispatch.submission_from_url('https://atcoder.jp/contests/agc039/submissions/7874055')
         self.assertIsInstance(submission, service.atcoder.AtCoderSubmission)
         self.assertIsInstance(submission.get_service(), service.atcoder.AtCoderService)
-        with self.assertRaises(Exception):
-            submission.get_problem()
         problem = submission.download_problem()
         self.assertEqual(problem.contest_id, "agc039")
         self.assertEqual(problem.problem_id, "agc039_b")

--- a/tests/dispatch.py
+++ b/tests/dispatch.py
@@ -13,11 +13,6 @@ class DispatchAtCoderTest(unittest.TestCase):
         self.assertEqual(problem.download_input_format(), '\r\n<var>N</var>\r\n<var>c_1c_2c_3…c_N</var>\r\n')
         self.assertEqual(problem.get_name(), 'センター採点')
 
-    def test_problem_from_url_via_submission(self):
-        problem = dispatch.problem_from_url('https://atcoder.jp/contests/abc143/submissions/8059168')
-        self.assertTrue(isinstance(problem, service.atcoder.AtCoderProblem))
-        self.assertEqual(problem.get_url(), 'https://atcoder.jp/contests/abc143/tasks/abc143_c')
-
     def test_submission_from_url(self):
         submission = dispatch.submission_from_url('https://atcoder.jp/contests/agc039/submissions/7874055')
         self.assertIsInstance(submission, service.atcoder.AtCoderSubmission)
@@ -62,6 +57,7 @@ class InvalidDispatchTest(unittest.TestCase):
     def test_problem_from_url(self):
         self.assertIsNone(dispatch.problem_from_url('https://atcoder.jp/contests/agc039'))
         self.assertIsNone(dispatch.problem_from_url("https://yukicoder.me/contests/241/"))
+        self.assertIsNone(dispatch.problem_from_url('https://atcoder.jp/contests/abc143/submissions/8059168'))
 
     def test_submission_from_url(self):
         self.assertIsNone(dispatch.submission_from_url('https://atcoder.jp/contests/agc039'))

--- a/tests/type.py
+++ b/tests/type.py
@@ -1,6 +1,7 @@
 import unittest
 
 from onlinejudge.dispatch import problem_from_url, service_from_url, submission_from_url
+from onlinejudge.service import atcoder
 from onlinejudge.type import Problem, Service, Submission
 
 
@@ -22,3 +23,9 @@ class TypeTest(unittest.TestCase):
     def test_submission_eq(self):
         self.assertEqual(submission_from_url('https://atcoder.jp/contests/abc143/submissions/8264863'), submission_from_url('https://atcoder.jp/contests/abc143/submissions/8264863'))
         self.assertNotEqual(submission_from_url('https://atcoder.jp/contests/abc143/submissions/8264863'), submission_from_url('https://atcoder.jp/contests/abc143/submissions/8264897'))
+
+    def test_download_contest(self):
+        submission = submission_from_url('https://atcoder.jp/contests/abc143/submissions/8059104')
+        contest = submission.download_contest()
+        self.assertIsInstance(contest, atcoder.AtCoderContest)
+        self.assertEqual(contest.contest_id, 'abc143')


### PR DESCRIPTION
Currently, no contests support `get_problem`. So we should use `download_problem` rather than `get_problem`.

And I found `get_problem` can't be supported for most contest. I investigated AtCoder, yukicoder and Codeforces.
Once we unsupport `get_problem`. If we need it in the future, we can re-implement it.