### PR TITLE
fix issue for opening browser in OSX

### DIFF
--- a/onlinejudge/_implementation/command/submit.py
+++ b/onlinejudge/_implementation/command/submit.py
@@ -142,7 +142,7 @@ def submit(args: 'argparse.Namespace') -> None:
         # show result
         if args.open:
             browser = webbrowser.get()
-            log.status('open the submission page with: %s', browser.name)
+            log.status('open the submission page with: %s', browser.name if hasattr(browser, 'name') else browser._name)
             opened = browser.open_new_tab(submission.get_url())
             if not opened:
                 log.failure('failed to open the url. please set the $BROWSER envvar')

--- a/onlinejudge/_implementation/command/submit.py
+++ b/onlinejudge/_implementation/command/submit.py
@@ -142,7 +142,7 @@ def submit(args: 'argparse.Namespace') -> None:
         # show result
         if args.open:
             browser = webbrowser.get()
-            log.status('open the submission page with: %s', browser.name if hasattr(browser, 'name') else browser._name)
+            log.status('open the submission page with browser')
             opened = browser.open_new_tab(submission.get_url())
             if not opened:
                 log.failure('failed to open the url. please set the $BROWSER envvar')


### PR DESCRIPTION
Hi! Thank you for providing the great OSS!
I am using online-judge-tools and it helps me a lot, but there is a little bit problem for me.
The code submission in macOS seems to be broken.
I just fixed the problem, so I am glad if you review the code.

When I submit the code with `oj` command, the error message like the following is shown every time:
```bash
$ oj submit https://atcoder.jp/contests/abc134/tasks/abc134_a main.cc
[x] problem recognized: AtCoderProblem.from_url('https://atcoder.jp/contests/abc134/tasks/abc134_a'): https://atcoder.jp/contests/abc134/tasks/abc134_a
[*] code (205 byte):
...
[x] sleep(3.00)
Are you sure? Please type "abca" abca
...
[x] 200 OK
[+] success: result: https://atcoder.jp/contests/abc134/submissions/8221095
Traceback (most recent call last):
  File "/Users/ny/.pyenv/versions/3.7.0/bin/oj", line 11, in <module>
    load_entry_point('online-judge-tools==7.2.2', 'console_scripts', 'oj')()
  File "/Users/ny/.pyenv/versions/3.7.0/lib/python3.7/site-packages/onlinejudge/_implementation/main.py", line 298, in main
    run_program(namespace, parser=parser)
  File "/Users/ny/.pyenv/versions/3.7.0/lib/python3.7/site-packages/onlinejudge/_implementation/main.py", line 275, in run_program
    submit(args)
  File "/Users/ny/.pyenv/versions/3.7.0/lib/python3.7/site-packages/onlinejudge/_implementation/command/submit.py", line 145, in submit
    log.status('open the submission page with: %s', browser.name)
AttributeError: 'MacOSXOSAScript' object has no attribute 'name'
```

Although the code submission itself succeeds, the browser does not launch after submission. This error seems to be caused by the attribute access to `browser.name`. In macOS, `webbrowser.get()` returns the `MacOSXOSAScript` object, and it inherits `BaseBrowser`. `BaseBrowser` object has `name` property, but **`MacOSXOSAScript` object has `_name` property instead of `name`** (I don't know why).

The actual implementation inside `webbrowser` library is shown below (the implementation is as same for Python v2.7 branch):
https://github.com/python/cpython/blob/4cb08b6c0ae6989d169dd48c2b24087941f6d0b0/Lib/webbrowser.py#L641-L643

Based on the above survey, I just replaced `browser.name` to `browser.name if hasattr(browser, 'name') else browser._name`. Note that I have not verified this code because I couldn't find how to set up the dev environment and the unit test raises a lot of errors that seem not to be related to my code. I have just checked that at least I could successfully open the web browser by this modification in my environment.