### PR TITLE
raise Not Implement Error from abstract method.

### DIFF
--- a/onlinejudge/type.py
+++ b/onlinejudge/type.py
@@ -362,4 +362,4 @@ class Submission(ABC):
     @classmethod
     @abstractmethod
     def from_url(cls, s: str) -> Optional['Submission']:
-        pass
+        raise NotImplementedError


### PR DESCRIPTION
Abstact methodなので、NotImplementErrorを投げるのが正しい気がします。