### PR TITLE
Issue/597

### DIFF
--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -303,24 +303,7 @@ def main(args: Optional[List[str]] = None) -> None:
         log.info('The operation you specified is not supported yet. Pull requests are welcome.')
         log.info('see: https://github.com/kmyk/online-judge-tools/blob/master/CONTRIBUTING.md')
         sys.exit(1)
-    except onlinejudge.type.NotLoggedInError as e:
-        log.debug('\n' + traceback.format_exc())
-        log.error(str(e))
-        sys.exit(1)
-    except requests.exceptions.HTTPError as e:
-        log.debug('\n' + traceback.format_exc())
-        log.error(str(e))
-        log.debug(traceback.format_exc())
-        sys.exit(1)
-    except requests.exceptions.InvalidURL as e:
-        log.debug('\n' + traceback.format_exc())
-        log.error(str(e))
-        sys.exit(1)
-    except onlinejudge.type.SampleParseError as e:
-        log.debug('\n' + traceback.format_exc())
-        log.error(str(e))
-        sys.exit(1)
-    except FileExistsError as e:
+    except Exception as e:
         log.debug('\n' + traceback.format_exc())
         log.error(str(e))
         sys.exit(1)

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -6,8 +6,6 @@ import sys
 import traceback
 from typing import List, Optional
 
-import requests.exceptions
-
 import onlinejudge
 import onlinejudge.__about__ as version
 import onlinejudge._implementation.logging as log

--- a/tests/main.py
+++ b/tests/main.py
@@ -1,0 +1,10 @@
+import unittest
+
+from onlinejudge._implementation import main
+
+
+class RequestExceptionTest(unittest.TestCase):
+    def test_invalid_url(self):
+        with self.assertRaises(SystemExit) as e:
+            main.main(["d", "http://invalid_contest"])
+        self.assertEqual(e.exception.code, 1)


### PR DESCRIPTION
For example, `ConnectionError` and `ProxyError` is not excepted.
You can reproduce `ConnectionError` by offline environment.
However, I have no idea how to reproduce these exceptions.

Tests for all exception is difficult and not should be done in this repository. But at least, `InvalidURL` should be tested.