### PR TITLE
Apply parse_content to Codeforces

### DIFF
--- a/onlinejudge/service/codeforces.py
+++ b/onlinejudge/service/codeforces.py
@@ -317,16 +317,11 @@ class CodeforcesProblem(onlinejudge.type.Problem):
         samples = onlinejudge._implementation.testcase_zipper.SampleZipper()
         for tag in soup.find_all('div', class_=re.compile('^(in|out)put$')):  # Codeforces writes very nice HTML :)
             log.debug('tag: %s', str(tag))
-            assert len(list(tag.children))
+            assert len(list(tag.children)) == 2  # if not 2, next line throws ValueError.
             title, pre = list(tag.children)
             assert 'title' in title.attrs['class']
             assert pre.name == 'pre'
-            s = ''
-            for it in pre.children:
-                if it.name == 'br':
-                    s += '\n'
-                else:
-                    s += it.string
+            s = utils.parse_content(pre)
             s = s.lstrip()
             samples.add(s.encode(), title.string)
         return samples.get()


### PR DESCRIPTION
Related to: #573 

In this PR,
- Apply parse_content to Codeforces.
- Fix assert logic in `onlinejudge/service/codeforces.py`.
