### PR TITLE
fix a bug of logging on terminals whose size is unknown

### DIFF
--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -333,7 +333,8 @@ def snip_large_file_content(content: bytes, limit: int, head: int, tail: int, bo
     except UnicodeDecodeError as e:
         return str(e)
     font = log.bold if bold else (lambda s: s)
-    char_in_line, _ = shutil.get_terminal_size(fallback=(80, 24))  # fallback is required for Circle CI. see https://github.com/kmyk/online-judge-tools/issues/609
+    char_in_line, _ = shutil.get_terminal_size()
+    char_in_line = max(char_in_line, 40)
 
     def snip_line_based():
         lines = text.splitlines(keepends=True)

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -334,7 +334,7 @@ def snip_large_file_content(content: bytes, limit: int, head: int, tail: int, bo
         return str(e)
     font = log.bold if bold else (lambda s: s)
     char_in_line, _ = shutil.get_terminal_size()
-    char_in_line = max(char_in_line, 40)
+    char_in_line = max(char_in_line, 40)  # shutil.get_terminal_size() may return too small values (e.g. (0, 0) on Circle CI) successfully (i.e. fallback is not used). see https://github.com/kmyk/online-judge-tools/pull/611
 
     def snip_line_based():
         lines = text.splitlines(keepends=True)

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -333,7 +333,7 @@ def snip_large_file_content(content: bytes, limit: int, head: int, tail: int, bo
     except UnicodeDecodeError as e:
         return str(e)
     font = log.bold if bold else (lambda s: s)
-    char_in_line, _ = shutil.get_terminal_size()
+    char_in_line, _ = shutil.get_terminal_size(fallback=(80, 24))  # fallback is required for Circle CI. see https://github.com/kmyk/online-judge-tools/issues/609
 
     def snip_line_based():
         lines = text.splitlines(keepends=True)


### PR DESCRIPTION
fix #609, reported by @yosupo06

`fallback` を指定すれば直るらしいので指定します。実際の環境で試してないですが、 `shutil.py` を読む限りではこれで直るはずです。
https://docs.python.org/ja/3/library/shutil.html#shutil.get_terminal_size