### PR TITLE
avoid the AtCoder practice contest since it requires registration

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -93,7 +93,7 @@ class AtCoderService(onlinejudge.type.Service):
 
     def is_logged_in(self, *, session: Optional[requests.Session] = None) -> bool:
         session = session or utils.get_default_session()
-        url = 'https://atcoder.jp/contests/practice/submit'
+        url = 'https://atcoder.jp/contests/agc001/submit'
         resp = _request('GET', url, session=session, allow_redirects=False)
         return resp.status_code == 200
 


### PR DESCRIPTION
https://atcoder.jp/contests/practice の問題を見たり提出をしたりするには「参加ボタン」を押す必要があるが、これを押してない人が `is_logged_in` 関数に触れると 404 するらしい (再現が難しすぎて確認はしていません)。これを直します。