### PR TITLE
throw exceptions if the titles of sample cases are abnormal

### DIFF
--- a/onlinejudge/_implementation/testcase_zipper.py
+++ b/onlinejudge/_implementation/testcase_zipper.py
@@ -19,12 +19,14 @@ class SampleZipper(object):
     def add(self, content: bytes, name: str) -> None:
         if self._dangling is None:
             if re.search('output', name, re.IGNORECASE) or re.search('出力', name):
-                log.warning('strange name for input string: %s', name)
+                log.error('strange name for input string: %s', name)
+                raise SampleParseError()
             self._dangling = (name, content)
         else:
             if re.search('input', name, re.IGNORECASE) or re.search('入力', name):
                 if not (re.search('output', name, re.IGNORECASE) or re.search('出力', name)):  # to ignore titles like "Output for Sample Input 1"
-                    log.warning('strange name for output string: %s', name)
+                    log.error('strange name for output string: %s', name)
+                    raise SampleParseError()
             index = len(self._testcases)
             input_name, input_content = self._dangling
             self._testcases += [TestCase('sample-{}'.format(index + 1), input_name, input_content, name, content)]

--- a/tests/command_download_atcoder.py
+++ b/tests/command_download_atcoder.py
@@ -157,3 +157,8 @@ class DownloadAtCoderTest(unittest.TestCase):
     def test_call_download_413(self):
         # This task is not supported.
         self.snippet_call_download_raises(SampleParseError, 'https://chokudai001.contest.atcoder.jp/tasks/chokudai_001_a')
+
+    def test_call_download_atcoder_s8pc_4_d(self):
+        # HTML is broken and impossible to recognize samples
+        # see https://github.com/kmyk/online-judge-tools/issues/615
+        self.snippet_call_download_raises(SampleParseError, 'https://atcoder.jp/contests/s8pc-4/tasks/s8pc_4_d')


### PR DESCRIPTION
fix #615 

サンプルの解析の際に `<h3>Sample Input 2</h3>` みたいなところを見て警告を出しているのですが、これを警告でなくエラーにします。

#615 の例を完全に解析しきるのは無理 (できたとしても HTML parser の実装に強く依存してしまうのでどうせすぐ壊れる) ですので、これは諦めます。しかし、まずいのはエラーにならず正常終了してしまうことなので、このプルリクによって #615 が解決されます。