### PR TITLE
add an internal method LibraryCheckerProblem.download_checker_cpp()

### DIFF
--- a/onlinejudge/service/library_checker.py
+++ b/onlinejudge/service/library_checker.py
@@ -116,6 +116,12 @@ class LibraryCheckerProblem(onlinejudge.type.Problem):
                 return cls(problem_id=m.group(1))
         return None
 
+    def download_checker_cpp(self) -> bytes:
+        self._generate_test_cases_in_cloned_repository()
+        path = self._get_problem_directory_path()
+        with open(str(path / "checker.cpp"), "rb") as fh:
+            return fh.read()
+
 
 onlinejudge.dispatch.services += [LibraryCheckerService]
 onlinejudge.dispatch.problems += [LibraryCheckerProblem]

--- a/onlinejudge/service/library_checker.py
+++ b/onlinejudge/service/library_checker.py
@@ -4,6 +4,7 @@ the module for yosupo's Library Checker (https://judge.yosupo.jp)
 """
 
 import os
+import pathlib
 import re
 import subprocess
 import sys
@@ -57,10 +58,10 @@ class LibraryCheckerProblem(onlinejudge.type.Problem):
         files += [(file.name, file.read_bytes()) for file in path.glob('out/*.out')]
         return onlinejudge._implementation.testcase_zipper.extract_from_files(iter(files))
 
-    def _get_cloned_repository_path(self):
+    def _get_cloned_repository_path(self) -> pathlib.Path:
         return utils.cache_dir / 'library-checker-problems'
 
-    def _generate_test_cases_in_cloned_repository(self):
+    def _generate_test_cases_in_cloned_repository(self) -> None:
         path = self._get_cloned_repository_path()
 
         try:
@@ -93,7 +94,7 @@ class LibraryCheckerProblem(onlinejudge.type.Problem):
                 log.error("the generate.py failed: check https://github.com/yosupo06/library-checker-problems/issues")
                 raise
 
-    def _get_problem_directory_path(self):
+    def _get_problem_directory_path(self) -> pathlib.Path:
         path = self._get_cloned_repository_path()
         problems = toml.load(path / 'problems.toml')
         return path / problems['problems'][self.problem_id]['dir']


### PR DESCRIPTION
judge.yosupo.jp は常に `checker.cpp` を用いた special judge 形式になっています (https://github.com/kmyk/online-judge-verify-helper/issues/1#issuecomment-558599240) が、この `checker.cpp` を取得できるようにします。
オプションとか別コマンドとかを作るとなると仕様を検討したくなってしまう (「yukicoder も special judge がありますが……」など) ので、とりあえず内部メソッドだけにしておきます。

たとえば `python3 -c 'import onlinejudge, sys ; sys.stdout.buffer.write(onlinejudge.dispatch.problem_from_url("https://judge.yosupo.jp/problem/unionfind").download_checker_cpp())'`  などとします。

---

- できれば 7.4.0 に一緒に入ってくれるとうれしい
- 用途は https://github.com/kmyk/online-judge-verify-helper/issues/19 です
- cc @yosupo06 @beet-aizu