### PR TITLE
Fix command_submit.py

### DIFF
--- a/tests/command_submit.py
+++ b/tests/command_submit.py
@@ -26,8 +26,8 @@ class SubmitArgumentsTest(unittest.TestCase):
             },
         ]
         with tests.utils.sandbox(files):
-            tests.utils.run(['dl', url], check=True)
-            tests.utils.run(['s', '-y', '--no-open', 'a.cpp'], check=True)
+            tests.utils.run(['dl', url], check=False)
+            tests.utils.run(['s', '-y', '--no-open', url, 'a.cpp'], check=True)
 
     @unittest.skipIf(os.name == 'nt', "shell script doesn't work on Windows")
     @unittest.skipIf(not tests.utils.is_logged_in(AtCoderService()), 'login is required')


### PR DESCRIPTION
#626 の修正により`FAILED`になったtestを発見したので修正します。
(Travisでは`SKIPPED`で通過していました)
<br>

修正1
```python3
tests.utils.run(['dl', url], check=False)
```
`False`にすることで(sampleが無いときに発生する)エラーを無視します。
<br>

修正2
```python3
tests.utils.run(['s', '-y', '--no-open', url, 'a.cpp'], check=True)
```
`url`の推論に失敗しているので、陽に指定します。
