### PR TITLE
provide functions about sessions as a library

### DIFF
--- a/docs/onlinejudge.rst
+++ b/docs/onlinejudge.rst
@@ -15,6 +15,7 @@ Submodules
 
    onlinejudge.dispatch
    onlinejudge.type
+   onlinejudge.utils
 
 Module contents
 ---------------

--- a/docs/onlinejudge.utils.rst
+++ b/docs/onlinejudge.utils.rst
@@ -1,0 +1,7 @@
+onlinejudge.utils module
+===========================
+
+.. automodule:: onlinejudge.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/onlinejudge/_implementation/download_history.py
+++ b/onlinejudge/_implementation/download_history.py
@@ -13,7 +13,7 @@ import onlinejudge.type
 
 
 class DownloadHistory(object):
-    def __init__(self, path: pathlib.Path = utils.cache_dir / 'download-history.jsonl'):
+    def __init__(self, path: pathlib.Path = utils.user_cache_dir / 'download-history.jsonl'):
         self.path = path
 
     def add(self, problem: onlinejudge.type.Problem, directory: pathlib.Path = pathlib.Path.cwd()) -> None:

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -353,6 +353,10 @@ class AtCoderContest(onlinejudge.type.Contest):
         return AtCoderService()
 
     def list_problem_data(self, *, session: Optional[requests.Session] = None) -> List['AtCoderProblemData']:
+        """
+        :raises Exception: if logging in is required to see the tasks page
+        """
+
         # get
         session = session or utils.get_default_session()
         url = 'https://atcoder.jp/contests/{}/tasks'.format(self.contest_id)
@@ -365,6 +369,7 @@ class AtCoderContest(onlinejudge.type.Contest):
         return [AtCoderProblemData._from_table_row(tr, session=session, response=resp, timestamp=timestamp) for tr in tbody.find_all('tr')]
 
     def list_problems(self, *, session: Optional[requests.Session] = None) -> Sequence['AtCoderProblem']:
+        # Even without logging in, we can list problems of some contests via standings pages, but some contests have no standings pages
         return tuple([data.problem for data in self.list_problem_data(session=session)])
 
     # yapf: disable

--- a/onlinejudge/service/library_checker.py
+++ b/onlinejudge/service/library_checker.py
@@ -59,7 +59,7 @@ class LibraryCheckerProblem(onlinejudge.type.Problem):
         return onlinejudge._implementation.testcase_zipper.extract_from_files(iter(files))
 
     def _get_cloned_repository_path(self) -> pathlib.Path:
-        return utils.cache_dir / 'library-checker-problems'
+        return utils.user_cache_dir / 'library-checker-problems'
 
     def _generate_test_cases_in_cloned_repository(self) -> None:
         path = self._get_cloned_repository_path()

--- a/onlinejudge/utils.py
+++ b/onlinejudge/utils.py
@@ -1,0 +1,64 @@
+# Python Version: 3.x
+"""
+the module for those who make programs using online-judge-tools as a library
+"""
+
+import contextlib
+import http
+import pathlib
+from typing import *
+
+import appdirs
+
+import onlinejudge.__about__ as version
+import onlinejudge._implementation.logging as log
+from onlinejudge.type import *
+
+user_config_dir = pathlib.Path(appdirs.user_config_dir(version.__package_name__))
+user_data_dir = pathlib.Path(appdirs.user_data_dir(version.__package_name__))
+user_cache_dir = pathlib.Path(appdirs.user_cache_dir(version.__package_name__))
+
+_default_session = None  # Optional[requests.Session]
+
+
+def _new_session_with_our_user_agent():
+    session = requests.Session()
+    session.headers['User-Agent'] = '{}/{} (+{})'.format(version.__package_name__, version.__version__, version.__url__)
+    log.debug('User-Agent: %s', session.headers['User-Agent'])
+    return session
+
+
+# NOTE: this function should not be used internally; if used, we may make bugs that given sessions are ignored
+def get_default_session() -> requests.Session:
+    """
+    get the default session used in online-judge-tools
+
+    :note: cookie is not saved to disk by default. check :py:func:`with_cookiejar`
+    """
+
+    global _default_session
+    if _default_session is None:
+        _default_session = _new_session_with_our_user_agent()
+    return _default_session
+
+
+default_cookie_path = user_data_dir / 'cookie.jar'
+
+
+@contextlib.contextmanager
+def with_cookiejar(session: requests.Session, *, path: pathlib.Path = default_cookie_path) -> Iterator[requests.Session]:
+    """
+
+    :param session: the session to set a cookiejar
+    :param path: a path to the file to store cookies. the default cookiejar is used if :py:class:`None`
+    """
+
+    session.cookies = http.cookiejar.LWPCookieJar(str(path))  # type: ignore
+    if path.exists():
+        log.status('load cookie from: %s', path)
+        session.cookies.load()  # type: ignore
+    yield session
+    log.status('save cookie to: %s', path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    session.cookies.save()  # type: ignore
+    path.chmod(0o600)  # NOTE: to make secure a little bit


### PR DESCRIPTION
https://github.com/kmyk/online-judge-tools/issues/480#issuecomment-565946620 

`onlinejudge._implementation.utils` のなかからいくつか `onlinejudge.utils` に移した

-   `get_default_session` `with_cookiejar`
-   `default_cookie_path` なども移した (`with_cookiejar` した結果から取れちゃうし、いっしょにあると便利だろうので)
-   関数名はとりあえずそのまま、module の名前は `onlinejudge.session` という手もあるが細かく切るよりひとつにまとめた方がなんとなく楽かな、ぐらいの気持ちです。より良いのが思い付いたら提案してください

@yosupo06 これはあなたの目的のためによさそうですか？ ところで atcoder-tools 並に高機能でかつ AtCoder 以外にも対応してるラッパーはほしいので、期待しています