### PR TITLE
update docs/run-ci-on-your-library.*.rst

### DIFF
--- a/docs/run-ci-on-your-library.en.rst
+++ b/docs/run-ci-on-your-library.en.rst
@@ -111,7 +111,7 @@ The color of this badge changes depending on the success or failure of CI.
 .. |badge| image:: https://img.shields.io/travis/kmyk/competitive-programming-library/master.svg
    :target: https://travis-ci.org/kmyk/competitive-programming-library
 
-(Caution: This section have been written before GitHub Actions is released. Now, I also recommend GitHub Actions not only Travis CI.)
+(Caution: This section have been written before GitHub Actions was released. Now, I also recommend GitHub Actions not only Travis CI.)
 
 
 Examples

--- a/docs/run-ci-on-your-library.ja.rst
+++ b/docs/run-ci-on-your-library.ja.rst
@@ -103,7 +103,7 @@ Travis CI のページ https://travis-ci.org/ から登録してライブラリ�
 .. |badge| image:: https://img.shields.io/travis/kmyk/competitive-programming-library/master.svg
    :target: https://travis-ci.org/kmyk/competitive-programming-library
 
-(注意: この節は GitHub Actiosn が public release される前に書かれました。現在では Travis CI でなく GitHub Actions を使ってみてもよいかもしれません。)
+(注意: この節は GitHub Actions が public release される前に書かれました。現在では Travis CI でなく GitHub Actions を使ってみてもよいかもしれません。)
 
 
 Examples


### PR DESCRIPTION
CI についてのドキュメントを更新します。
内容:

- https://github.com/kmyk/online-judge-verify-helper について追加
- それにともなって、スクリプトの例を実用よりのものから動作内容の説明よりのものに寄せて修正
- GitHub Actions が使えるようになったので、どちらかというとこちらの方がおすすめであることを記述

プレビュー (つまりユーザに見せるための URL ではない) は https://github.com/kmyk/online-judge-tools/blob/16eaf0a190e31b56faa97eb30222c0c3fee9635c/docs/run-ci-on-your-library.ja.rst とかから見れます。