### PR TITLE
fix broken test name

### DIFF
--- a/tests/command_download_invalid.py
+++ b/tests/command_download_invalid.py
@@ -6,7 +6,7 @@ import tests.command_download
 from onlinejudge.type import SampleParseError
 
 
-class DownloadInvalid(unittest.TestCase):
+class DownloadInvalidTest(unittest.TestCase):
     def snippet_call_download_raises(self, *args, **kwargs):
         tests.command_download.snippet_call_download_raises(self, *args, **kwargs)
 


### PR DESCRIPTION
Unfortunately, I mistook again.
I verified test class name by `grep` command and other class names are right.