### PR TITLE
Fix a bug of git pull about Library Checker

### DIFF
--- a/onlinejudge/service/library_checker.py
+++ b/onlinejudge/service/library_checker.py
@@ -62,8 +62,8 @@ class LibraryCheckerService(onlinejudge.type.Service):
             subprocess.check_call(['git', 'clone', url, str(path)], stdout=sys.stdout, stderr=sys.stderr)
         else:
             # sync the problem repository
-            log.status('$ git --git-dir %s pull', str(path / '.git'))
-            subprocess.check_call(['git', '--git-dir', str(path / '.git'), 'pull'], stdout=sys.stdout, stderr=sys.stderr)
+            log.status('$ git -C %s pull', str(path))
+            subprocess.check_call(['git', '-C', str(path), 'pull'], stdout=sys.stdout, stderr=sys.stderr)
 
         cls.is_repository_updated = True
 

--- a/tests/service_library_checker.py
+++ b/tests/service_library_checker.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import unittest
 
@@ -19,11 +20,13 @@ class LibraryCheckerProblemTest(unittest.TestCase):
     def test_from_url(self):
         self.assertEqual(LibraryCheckerProblem.from_url('https://judge.yosupo.jp/problem/point_add_range_sum').problem_id, 'point_add_range_sum')
 
+    @unittest.skipIf(os.name == 'nt', "Library Checker is not supported on Windows")
     def test_download_samples(self):
         self.assertEqual(LibraryCheckerProblem.from_url('https://judge.yosupo.jp/problem/unionfind').download_sample_cases(), [
             TestCase(name='example_00', input_name='example_00.in', input_data=b'4 7\n1 0 1\n0 0 1\n0 2 3\n1 0 1\n1 1 2\n0 0 2\n1 1 3\n', output_name='example_00.out', output_data=b'0\n1\n0\n1\n'),
         ])
 
+    @unittest.skipIf(os.name == 'nt', "Library Checker is not supported on Windows")
     def test_pull_repository(self):
         # reset
         LibraryCheckerService.is_repository_updated = False

--- a/tests/service_library_checker.py
+++ b/tests/service_library_checker.py
@@ -1,5 +1,9 @@
+import subprocess
 import unittest
 
+import tests.utils as utils
+
+import onlinejudge.utils
 from onlinejudge.service.library_checker import LibraryCheckerProblem, LibraryCheckerService
 from onlinejudge.type import TestCase
 
@@ -18,4 +22,17 @@ class LibraryCheckerProblemTest(unittest.TestCase):
     def test_download_samples(self):
         self.assertEqual(LibraryCheckerProblem.from_url('https://judge.yosupo.jp/problem/unionfind').download_sample_cases(), [
             TestCase(name='example_00', input_name='example_00.in', input_data=b'4 7\n1 0 1\n0 0 1\n0 2 3\n1 0 1\n1 1 2\n0 0 2\n1 1 3\n', output_name='example_00.out', output_data=b'0\n1\n0\n1\n'),
+        ])
+
+    def test_pull_repository(self):
+        # reset
+        LibraryCheckerService.is_repository_updated = False
+        with utils.chdir(str(onlinejudge.utils.user_cache_dir / 'library-checker-problems')):
+            # the first commit https://github.com/yosupo06/library-checker-problems/commit/fb33114329382695b1a17655843b490b04a08ab6
+            subprocess.check_call(['git', 'reset', '--hard', 'fb33114329382695b1a17655843b490b04a08ab6'])
+
+        # ensure that it automatically runs `$ git pull`
+        self.assertEqual(LibraryCheckerProblem.from_url('https://judge.yosupo.jp/problem/aplusb').download_sample_cases(), [
+            TestCase(name='example_00', input_name='example_00.in', input_data=b'1234 5678\n', output_name='example_00.out', output_data=b'6912\n'),
+            TestCase(name='example_01', input_name='example_01.in', input_data=b'1000000000 1000000000\n', output_name='example_01.out', output_data=b'2000000000\n'),
         ])

--- a/tests/service_library_checker.py
+++ b/tests/service_library_checker.py
@@ -1,0 +1,21 @@
+import unittest
+
+from onlinejudge.service.library_checker import LibraryCheckerProblem, LibraryCheckerService
+from onlinejudge.type import TestCase
+
+
+class LibraryCheckerSerivceTest(unittest.TestCase):
+    def test_from_url(self):
+        self.assertIsInstance(LibraryCheckerService.from_url('https://judge.yosupo.jp/'), LibraryCheckerService)
+        self.assertIsInstance(LibraryCheckerService.from_url('https://judge.yosupo.jp/problem/point_add_range_sum'), LibraryCheckerService)
+        self.assertIsNone(LibraryCheckerService.from_url('https://www.facebook.com/'))
+
+
+class LibraryCheckerProblemTest(unittest.TestCase):
+    def test_from_url(self):
+        self.assertEqual(LibraryCheckerProblem.from_url('https://judge.yosupo.jp/problem/point_add_range_sum').problem_id, 'point_add_range_sum')
+
+    def test_download_samples(self):
+        self.assertEqual(LibraryCheckerProblem.from_url('https://judge.yosupo.jp/problem/unionfind').download_sample_cases(), [
+            TestCase(name='example_00', input_name='example_00.in', input_data=b'4 7\n1 0 1\n0 0 1\n0 2 3\n1 0 1\n1 1 2\n0 0 2\n1 1 3\n', output_name='example_00.out', output_data=b'0\n1\n0\n1\n'),
+        ])


### PR DESCRIPTION
`git pull` をするときにオプションの指定を間違えてて Library Checker 対応が壊れていました。
これを修正し、テストを足しました。

参考: https://this.aereal.org/entry/2014/05/19/192043