### PR TITLE
Use python_requires='>=3.5' in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     url=version.__url__,
     license=version.__license__,
     description=version.__description__,
+    python_requires='>=3.5',
     install_requires=[
         'appdirs >= 1',
         'beautifulsoup4 >= 4',


### PR DESCRIPTION
`pip install -U online-judge-tools` ってして Python 2.x のライブラリ扱いでインストールされてしまって動かなくて困るやつをやったことはありませんか？ 私はわりとやるのでこれを対策します。