### PR TITLE
RELEASE: 7.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 7.8.0 / 2019-02-03
+
+-   [#665](https://github.com/kmyk/online-judge-tools/pull/665) add Sphere Online Judge support
+-   [#661](https://github.com/kmyk/online-judge-tools/pull/661) allow `submit` to guess more languages ([@eggplants](https://github.com/eggplants))
+-   [#660](https://github.com/kmyk/online-judge-tools/pull/660) prevent installation using unsupported versions of Python
 
 ## 7.7.0 / 2019-01-20
 -   [#654](https://github.com/kmyk/online-judge-tools/pull/654) fix a bug of git pull option about Library Checker

--- a/onlinejudge/__about__.py
+++ b/onlinejudge/__about__.py
@@ -4,6 +4,6 @@ __author__ = 'Kimiyuki Onaka'
 __email__ = 'kimiyuki95@gmail.com'
 __license__ = 'MIT License'
 __url__ = 'https://github.com/kmyk/online-judge-tools'
-__version_info__ = (7, 7, 0, 'final', 0)
+__version_info__ = (7, 8, 0, 'final', 0)
 __version__ = '.'.join(map(str, __version_info__[:3]))
 __description__ = 'Tools for online-judge services'


### PR DESCRIPTION
バージョンを上げます。
いまあるプルリクはマージまでしばらくかかりそうなこと、すでにマージされたプルリクの反映をはやめにしておきたいことが理由です。