### PR TITLE
Fix test to deal with re-judge

### DIFF
--- a/tests/service_yukicoder.py
+++ b/tests/service_yukicoder.py
@@ -189,7 +189,7 @@ class YukicoderOfficialAPITest(unittest.TestCase):
     def test_get_submissions(self):
         data = YukicoderService().get_submissions(page=3, status='TLE')
         self.assertEqual(len(data), 50)
-        self.assertEqual(data[4]['結果'], 'TLE')
+        self.assertTrue('TLE' == data[4]['結果'] or 'TLE\n(最新)' in data[4]['結果'])
 
     def test_get_problems(self):
         data = YukicoderService().get_problems(page=2, sort='no_asc')

--- a/tests/service_yukicoder.py
+++ b/tests/service_yukicoder.py
@@ -189,6 +189,7 @@ class YukicoderOfficialAPITest(unittest.TestCase):
     def test_get_submissions(self):
         data = YukicoderService().get_submissions(page=3, status='TLE')
         self.assertEqual(len(data), 50)
+        # yukicoder returns sentence such as 'TLE\n(最新)--\nAC' when the submission was rejudged and judge status was changed.
         self.assertTrue('TLE' == data[4]['結果'] or 'TLE\n(最新)' in data[4]['結果'])
 
     def test_get_problems(self):


### PR DESCRIPTION
Test about yukicoder sometimes fails because of unexpected re-judged status sentence.

![image](https://user-images.githubusercontent.com/44835435/74337426-9c18b000-4de3-11ea-9966-1b9f8c2bae41.png)

(This screenshot was taken in [Travis CI Job #1445.1](https://travis-ci.org/kmyk/online-judge-tools/jobs/649196499?utm_medium=notification&utm_source=github_status).)
