### PR TITLE
side-by-side-diff: display number of snipped lines.

### DIFF
--- a/onlinejudge/_implementation/command/test.py
+++ b/onlinejudge/_implementation/command/test.py
@@ -309,31 +309,34 @@ def display_snipped_side_by_side_color(answer: str, expected: str):
     Display first differ line and its previous 3 lines and its next 3 lines.
     """
     max_chars = shutil.get_terminal_size()[0] // 2 - 2
-    deq = collections.deque(maxlen=7)  # type: Deque[Tuple[str, bool, str, str, int, int]]
+    deq = collections.deque(maxlen=7)  # type: Deque[Tuple[int, bool, str, str, int, int]]
 
     count_from_first_difference = 0
     for i, (diff_found, ans_line, exp_line, ans_chars, exp_chars) in enumerate(side_by_side_diff(answer, expected)):
         if count_from_first_difference > 0:
             count_from_first_difference += 1
-        deq.append((str(i + 1), diff_found, ans_line, exp_line, ans_chars, exp_chars))
+        deq.append((i + 1, diff_found, ans_line, exp_line, ans_chars, exp_chars))
         if diff_found:
             if count_from_first_difference == 0:
                 count_from_first_difference = 1
         if count_from_first_difference == 4:
             break
 
-    max_line_num_digits = max([len(entry[0]) for entry in deq])
+    max_line_num_digits = max([len(str(entry[0])) for entry in deq])
 
     log.emit(" " * max_line_num_digits + "|output:" + " " * (max_chars - 7 - max_line_num_digits - 1) + "|" + "expected:")
     log.emit("-" * max_chars + "|" + "-" * max_chars)
 
-    for (str_i, diff_found, ans_line, exp_line, ans_chars, exp_chars) in deq:
+    for (line_number, diff_found, ans_line, exp_line, ans_chars, exp_chars) in deq:
         num_spaces_after_output = max_chars - ans_chars - max_line_num_digits - 1
-        line_num_display = space_padding(str_i, max_line_num_digits - len(str_i)) + "|"
+        line_num_display = space_padding(str(line_number), max_line_num_digits - len(str(line_number))) + "|"
         if not diff_found:
             log.emit(line_num_display + space_padding(ans_line, num_spaces_after_output) + "|" + exp_line)
         else:
             log.emit(line_num_display + log.red(space_padding(ans_line, num_spaces_after_output)) + "|" + log.green(exp_line))
+    num_snipped_lines = answer.count('\n') + 1 - line_number
+    if num_snipped_lines > 0:
+        log.emit('... ({} lines) ...'.format(num_snipped_lines))
 
 
 def yield_open_entry(open_entry: Tuple[List[str], List[str], List[int], List[int]]) -> Generator[Tuple[bool, str, str, int, int], None, None]:

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -1057,6 +1057,43 @@ class TestTestLog(unittest.TestCase):
                 '42|' + ' ' * (self.max_chars - 3) + '|',
                 '43|' + ' ' * (self.max_chars - 3) + '|',
                 '44|' + ' ' * (self.max_chars - 3) + '|',
+                '... (7 lines) ...',
+                '',
+                '[x] slowest:',
+                '[x] max memory:',
+                '[-] test failed: 0 AC / 1 cases',
+                '',
+            ],
+        )
+
+    def test_side_by_side_long2(self):
+        self.snippet_call_test(
+            args=['-m', 'side-by-side', '-c', cat(), '--no-rstrip'],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': os.linesep * 50 + '1'
+                },
+                {
+                    'path': 'test/sample-1.out',
+                    'data': os.linesep * 50 + '2'
+                },
+            ],
+            expected_log_lines=[
+                '[*] 1 cases found',
+                '',
+                '[*] sample-1',
+                '[x] ',
+                '[-] WA',
+                '  |output:' + ' ' * (self.max_chars - 10) + '|expected:',
+                '-' * self.max_chars + '|' + '-' * self.max_chars,
+                '45|' + ' ' * (self.max_chars - 3) + '|',
+                '46|' + ' ' * (self.max_chars - 3) + '|',
+                '47|' + ' ' * (self.max_chars - 3) + '|',
+                '48|' + ' ' * (self.max_chars - 3) + '|',
+                '49|' + ' ' * (self.max_chars - 3) + '|',
+                '50|' + ' ' * (self.max_chars - 3) + '|',
+                '51|1                                  |2',
                 '',
                 '[x] slowest:',
                 '[x] max memory:',
@@ -1170,9 +1207,10 @@ class TestTestSnippedSideBySideLog(unittest.TestCase):
             '45|' + logging.red(logging.red_diff('Alice') + ' ' * (self.max_chars - 8)) + '|' + logging.green(logging.green_diff('John')),
             '46|Bob' + ' ' * (self.max_chars - 6) + '|Bob',
             '47|Alice' + ' ' * (self.max_chars - 8) + '|Alice',
+            '... (1 lines) ...',
         ]
-        output = ('\n' * 40 + 'Alice\nBob\nAlice\nBob\nAlice\nBob\nAlice\nBob\n').replace('\n', os.linesep)
-        expect = ('\n' * 40 + 'Alice\nBob\nAlice\nJohn\nJohn\nBob\nAlice\nBob\n').replace('\n', os.linesep)
+        output = ('\n' * 40 + 'Alice\nBob\nAlice\nBob\nAlice\nBob\nAlice\nBob').replace('\n', os.linesep)
+        expect = ('\n' * 40 + 'Alice\nBob\nAlice\nJohn\nJohn\nBob\nAlice\nBob').replace('\n', os.linesep)
         self.snippet_call_test(output, expect, display_lines, 2)
 
     def test_side_by_side2(self):
@@ -1184,7 +1222,8 @@ class TestTestSnippedSideBySideLog(unittest.TestCase):
             '102|' + logging.red(logging.red_diff('Alice') + ' ' * (self.max_chars - 9)) + '|' + logging.green(logging.green_diff('John')),
             '103|Bob' + ' ' * (self.max_chars - 7) + '|Bob',
             '104|Alice' + ' ' * (self.max_chars - 9) + '|Alice',
+            '... (1 lines) ...',
         ]
-        output = ('\n' * 97 + 'Alice\nBob\nAlice\nBob\nAlice\nBob\nAlice\nBob\n').replace('\n', os.linesep)
-        expect = ('\n' * 97 + 'Alice\nBob\nAlice\nJohn\nJohn\nBob\nAlice\nBob\n').replace('\n', os.linesep)
+        output = ('\n' * 97 + 'Alice\nBob\nAlice\nBob\nAlice\nBob\nAlice\nBob').replace('\n', os.linesep)
+        expect = ('\n' * 97 + 'Alice\nBob\nAlice\nJohn\nJohn\nBob\nAlice\nBob').replace('\n', os.linesep)
         self.snippet_call_test(output, expect, display_lines, 3)


### PR DESCRIPTION
side-by-sideモードで省略された行がある時、後ろが何行省略されたか表示するようにしました。
(outputとexpectで微妙に違うが、outputの行数基準)
前の行も省略されることがありますが、行番号書いてあるので大丈夫でしょう。

#684 