### PR TITLE
Coloroize trailing spaces

### DIFF
--- a/onlinejudge/_implementation/command/download.py
+++ b/onlinejudge/_implementation/command/download.py
@@ -73,7 +73,7 @@ def download(args: 'argparse.Namespace') -> None:
             path = args.directory / format_utils.percentformat(args.format, table)  # type: pathlib.Path
             log.status('%sput: %s', ext, name)
             if not args.silent:
-                log.emit(utils.snip_large_file_content(data, limit=40, head=20, tail=10, bold=True))
+                log.emit(utils.make_pretty_large_file_content(data, limit=40, head=20, tail=10, bold=True))
             if args.dry_run:
                 continue
             if path.exists():

--- a/onlinejudge/_implementation/command/generate_input.py
+++ b/onlinejudge/_implementation/command/generate_input.py
@@ -43,7 +43,7 @@ def write_result(input_data: bytes, output_data: Optional[bytes], *, input_path:
 
         if print_data:
             log.emit('input:')
-            log.emit(utils.snip_large_file_content(input_data, limit=40, head=20, tail=10, bold=True))
+            log.emit(utils.make_pretty_large_file_content(input_data, limit=40, head=20, tail=10, bold=True))
         with input_path.open('wb') as fh:
             fh.write(input_data)
         log.success('saved to: %s', input_path)
@@ -51,7 +51,7 @@ def write_result(input_data: bytes, output_data: Optional[bytes], *, input_path:
         if output_data is not None:
             if print_data:
                 log.emit('output:')
-                log.emit(utils.snip_large_file_content(output_data, limit=40, head=20, tail=10, bold=True))
+                log.emit(utils.make_pretty_large_file_content(output_data, limit=40, head=20, tail=10, bold=True))
             with output_path.open('wb') as fh:
                 fh.write(output_data)
             log.success('saved to: %s', output_path)
@@ -149,9 +149,9 @@ def try_hack_once(generator: str, command: str, hack: str, *, tle: Optional[floa
         expected = output_data.decode()
         if not simple_match(answer, expected):
             log.failure(log.red('WA'))
-            log.emit('input:\n%s', utils.snip_large_file_content(input_data, limit=40, head=20, tail=10, bold=True))
-            log.emit('output:\n%s', utils.snip_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
-            log.emit('expected:\n%s', utils.snip_large_file_content(output_data, limit=40, head=20, tail=10, bold=True))
+            log.emit('input:\n%s', utils.make_pretty_large_file_content(input_data, limit=40, head=20, tail=10, bold=True))
+            log.emit('output:\n%s', utils.make_pretty_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
+            log.emit('expected:\n%s', utils.make_pretty_large_file_content(output_data, limit=40, head=20, tail=10, bold=True))
             status = 'WA'
 
         if status == 'AC':

--- a/onlinejudge/_implementation/command/generate_output.py
+++ b/onlinejudge/_implementation/command/generate_output.py
@@ -45,7 +45,7 @@ def generate_output_single_case(test_name: str, test_input_path: pathlib.Path, *
             log.info('skipped.')
             return
         assert answer is not None
-        log.emit(utils.snip_large_file_content(answer, limit=40, head=20, tail=10, bold=True))
+        log.emit(utils.make_pretty_large_file_content(answer, limit=40, head=20, tail=10, bold=True))
 
         # find the destination path
         match_result = fmtutils.match_with_format(args.directory, args.format, test_input_path)  # type: Optional[Match[Any]]

--- a/onlinejudge/_implementation/command/submit.py
+++ b/onlinejudge/_implementation/command/submit.py
@@ -49,7 +49,7 @@ def submit(args: 'argparse.Namespace') -> None:
 
     # report code
     log.info('code (%d byte):', len(code))
-    log.emit(utils.snip_large_file_content(code, limit=30, head=10, tail=10, bold=True))
+    log.emit(utils.make_pretty_large_file_content(code, limit=30, head=10, tail=10, bold=True))
 
     with utils.with_cookiejar(utils.new_session_with_our_user_agent(), path=args.cookie) as sess:
         # guess or select language ids

--- a/onlinejudge/_implementation/command/test.py
+++ b/onlinejudge/_implementation/command/test.py
@@ -81,7 +81,7 @@ def compare_and_report(proc: subprocess.Popen, answer: str, memory: Optional[flo
                 log.status('$ %s', actual_command)
                 info, proc = utils.exec_command(actual_command)
                 if not silent:
-                    log.emit('judge\'s output:\n%s', utils.snip_large_file_content(info['answer'] or b'', limit=40, head=20, tail=10, bold=True))
+                    log.emit('judge\'s output:\n%s', utils.make_pretty_large_file_content(info['answer'] or b'', limit=40, head=20, tail=10, bold=True))
                 judge_result = (proc.returncode == 0)
             finally:
                 os.unlink(user_output.name)
@@ -104,7 +104,7 @@ def compare_and_report(proc: subprocess.Popen, answer: str, memory: Optional[flo
         if does_print_input and not is_input_printed:
             is_input_printed = True
             with test_input_path.open('rb') as inf:
-                log.emit('input:\n%s', utils.snip_large_file_content(inf.read(), limit=40, head=20, tail=10, bold=True))
+                log.emit('input:\n%s', utils.make_pretty_large_file_content(inf.read(), limit=40, head=20, tail=10, bold=True))
 
     # check TLE, RE or not
     status = 'AC'
@@ -135,8 +135,8 @@ def compare_and_report(proc: subprocess.Popen, answer: str, memory: Optional[flo
             print_input()
             if not silent:
                 if mode == 'simple':
-                    log.emit('output:\n%s', utils.snip_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
-                    log.emit('expected:\n%s', utils.snip_large_file_content(expected.encode(), limit=40, head=20, tail=10, bold=True))
+                    log.emit('output:\n%s', utils.make_pretty_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
+                    log.emit('expected:\n%s', utils.make_pretty_large_file_content(expected.encode(), limit=40, head=20, tail=10, bold=True))
                 elif mode == 'side-by-side':
                     if max(answer.count('\n'), expected.count('\n')) <= 40:
                         display_side_by_side_color(answer, expected)
@@ -147,7 +147,7 @@ def compare_and_report(proc: subprocess.Popen, answer: str, memory: Optional[flo
             status = 'WA'
     else:
         if not silent:
-            log.emit(('output:\n%s' if is_input_printed else '%s'), utils.snip_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
+            log.emit(('output:\n%s' if is_input_printed else '%s'), utils.make_pretty_large_file_content(answer.encode(), limit=40, head=20, tail=10, bold=True))
     if status == 'AC':
         log.success(log.green('AC'))
 

--- a/onlinejudge/_implementation/logging.py
+++ b/onlinejudge/_implementation/logging.py
@@ -79,3 +79,4 @@ green = lambda s: colorama.Fore.GREEN + s + colorama.Fore.RESET
 red = lambda s: colorama.Fore.RED + s + colorama.Fore.RESET
 green_diff = lambda s: colorama.Fore.RESET + colorama.Back.GREEN + colorama.Style.BRIGHT + s + colorama.Style.NORMAL + colorama.Back.RESET + colorama.Fore.GREEN
 red_diff = lambda s: colorama.Fore.RESET + colorama.Back.RED + colorama.Style.BRIGHT + s + colorama.Style.NORMAL + colorama.Back.RESET + colorama.Fore.RED
+dim = lambda s: colorama.Style.RESET_ALL + colorama.Style.DIM + s + colorama.Style.RESET_ALL

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -338,7 +338,7 @@ def make_pretty_large_file_content(content: bytes, limit: int, head: int, tail: 
             *map(font, text[-char_in_line * tail:].splitlines(keepends=True)),
         ])]
 
-    candidates: List[str] = []
+    candidates = []  # type: List[str]
     candidates += no_snip_text()
     candidates += snip_line_based()
     candidates += snip_char_based()

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -298,7 +298,7 @@ def make_pretty_large_file_content(content: bytes, limit: int, head: int, tail: 
 
     def font(line: str) -> str:
         if not line.endswith('\n'):
-            line += log.dim('(no trailing spaces)')
+            line += log.dim('(no trailing newline)')
         else:
 
             def repl(m):

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -297,8 +297,17 @@ def make_pretty_large_file_content(content: bytes, limit: int, head: int, tail: 
         return str(e)
 
     def font(line: str) -> str:
-        repl = lambda m: log.dim(m.group(1).replace(' ', '_').replace('\t', '\\t').replace('\r', '\\r') + '(trailing spaces)' + m.group(2))
-        line, _ = re.subn(r'(\s+)(\n)', repl, line)
+        if not line.endswith('\n'):
+            line += log.dim('(no trailing spaces)')
+        else:
+
+            def repl(m):
+                if m.group(1) == '\r':
+                    return log.dim('\\r' + m.group(2))
+                else:
+                    return log.dim(m.group(1).replace(' ', '_').replace('\t', '\\t').replace('\r', '\\r') + '(trailing spaces)' + m.group(2))
+
+            line = re.sub(r'(\s+)(\n)$', repl, line)
         if bold:
             line = log.bold(line)
         return line

--- a/onlinejudge/_implementation/utils.py
+++ b/onlinejudge/_implementation/utils.py
@@ -8,6 +8,7 @@ import http.cookiejar
 import json
 import os
 import posixpath
+import re
 import shlex
 import shutil
 import subprocess
@@ -288,38 +289,51 @@ def getter_with_load_details(name: str, type: Union[str, type]) -> Callable:
     return wrapper
 
 
-def snip_large_file_content(content: bytes, limit: int, head: int, tail: int, bold: bool = False) -> str:
+def make_pretty_large_file_content(content: bytes, limit: int, head: int, tail: int, bold: bool = False) -> str:
     assert head + tail < limit
     try:
         text = content.decode()
     except UnicodeDecodeError as e:
         return str(e)
-    font = log.bold if bold else (lambda s: s)
+
+    def font(line: str) -> str:
+        repl = lambda m: log.dim(m.group(1).replace(' ', '_').replace('\t', '\\t').replace('\r', '\\r') + '(trailing spaces)' + m.group(2))
+        line, _ = re.subn(r'(\s+)(\n)', repl, line)
+        if bold:
+            line = log.bold(line)
+        return line
+
     char_in_line, _ = shutil.get_terminal_size()
     char_in_line = max(char_in_line, 40)  # shutil.get_terminal_size() may return too small values (e.g. (0, 0) on Circle CI) successfully (i.e. fallback is not used). see https://github.com/kmyk/online-judge-tools/pull/611
 
-    def snip_line_based():
+    def no_snip_text() -> List[str]:
+        lines = text.splitlines(keepends=True)
+        return [''.join(map(font, lines))]
+
+    def snip_line_based() -> List[str]:
         lines = text.splitlines(keepends=True)
         if len(lines) < limit:
-            return font(text)
-        else:
-            return ''.join([
-                font(''.join(lines[:head])),
-                '... ({} lines) ...\n'.format(len(lines[head:-tail])),
-                font(''.join(lines[-tail:])),
-            ])
+            return []
+        return [''.join([
+            *map(font, lines[:head]),
+            '... ({} lines) ...\n'.format(len(lines[head:-tail])),
+            *map(font, lines[-tail:]),
+        ])]
 
-    def snip_char_based():
+    def snip_char_based() -> List[str]:
         if len(text) < char_in_line * limit:
-            return font(text)
-        else:
-            return ''.join([
-                font(text[:char_in_line * head]),
-                '... ({} chars) ...'.format(len(text[char_in_line * head:-char_in_line * tail])),
-                font(text[-char_in_line * tail:]),
-            ])
+            return []
+        return [''.join([
+            *map(font, text[:char_in_line * head].splitlines(keepends=True)),
+            '... ({} chars) ...'.format(len(text[char_in_line * head:-char_in_line * tail])),
+            *map(font, text[-char_in_line * tail:].splitlines(keepends=True)),
+        ])]
 
-    return min([font(text), snip_line_based(), snip_char_based()], key=len)
+    candidates: List[str] = []
+    candidates += no_snip_text()
+    candidates += snip_line_based()
+    candidates += snip_char_based()
+    return min(candidates, key=len)
 
 
 class DummySubmission(Submission):

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -991,6 +991,45 @@ class TestTestLog(unittest.TestCase):
         print(result['proc'].stderr.decode(), file=sys.stderr)
         self.check_log_lines(result['proc'].stderr.decode().split(os.linesep), expected_log_lines)
 
+    def test_trailing_spaces(self):
+        self.snippet_call_test(
+            args=['-c', tests.utils.python_c(r"import sys; sys.stdout.buffer.write(b'1\r\n2 \r\n3\n4  \t  \n5  \n6')")],
+            files=[
+                {
+                    'path': 'test/sample-1.in',
+                    'data': '',
+                },
+                {
+                    'path': 'test/sample-1.out',
+                    'data': '1\n2\n3\n',
+                },
+            ],
+            expected_log_lines=[
+                '[*] 1 cases found',
+                '',
+                '[*] sample-1',
+                '[x] time:',
+                '[-] WA',
+                'output:',
+                r'1\r',
+                r'2_\r(trailing spaces)',
+                r'3',
+                r'4__\t__(trailing spaces)',
+                r'5__(trailing spaces)',
+                r'6(no trailing newline)',
+                'expected:',
+                '1',
+                '2',
+                '3',
+                '',
+                '',
+                '[x] slowest:',
+                '[x] max memory:',
+                '[-] test failed: 0 AC / 1 cases',
+                '',
+            ],
+        )
+
     def test_side_by_short(self):
         self.snippet_call_test(
             args=['-m', 'side-by-side', '-c', cat(), '--no-rstrip'],


### PR DESCRIPTION
fix #698 
cc @azarashi2931
末尾空白が見えるようにします。

行末尾空白を AC にはできません。最近の AtCoder では多少の空白はあっても AC になるけど、古い問題だとそうとは限らないためです。ちなみに、ファイル末尾空白は許されるより場合が多いので AC になってるけど、これも実は怪しい挙動です。


![Screenshot from 2020-03-17 02-40-05](https://user-images.githubusercontent.com/2203128/76785356-a40bab80-67f8-11ea-8ff7-d16e7c699356.png)
