### PR TITLE
Improve submitting Python code

### DIFF
--- a/onlinejudge/_implementation/command/submit.py
+++ b/onlinejudge/_implementation/command/submit.py
@@ -249,7 +249,7 @@ def guess_lang_ids_of_file(filename: pathlib.Path, code: bytes, language_dict, c
                         versions += [version]
                 if not versions:
                     log.status('no version info in code')
-                    versions = [2, 3]
+                    versions = [3]
             log.status('use: %s', ', '.join(map(str, versions)))
 
             saved_ids = lang_ids

--- a/onlinejudge/_implementation/command/submit.py
+++ b/onlinejudge/_implementation/command/submit.py
@@ -230,7 +230,9 @@ def guess_lang_ids_of_file(filename: pathlib.Path, code: bytes, language_dict, c
             lang_ids += select('pypy', language_dict.keys())
 
         # version
-        if select_words(['python', '2'], lang_ids) and select_words(['python', '3'], lang_ids):
+        two_found = select_words(['python', '2'], lang_ids) or select_words(['pypy', '2'], lang_ids)
+        three_found = select_words(['python', '3'], lang_ids) or select_words(['pypy', '3'], lang_ids)
+        if two_found and three_found:
             log.status('both Python2 and Python3 are available for version of Python')
             if python_version in ('2', '3'):
                 versions = [int(python_version)]
@@ -257,6 +259,8 @@ def guess_lang_ids_of_file(filename: pathlib.Path, code: bytes, language_dict, c
             for version in versions:
                 lang_ids += select('python%d' % version, saved_ids)
                 lang_ids += select('python %d' % version, saved_ids)
+                lang_ids += select('pypy%d' % version, saved_ids)
+                lang_ids += select('pypy %d' % version, saved_ids)
 
         lang_ids = list(set(lang_ids))
         return lang_ids

--- a/onlinejudge/_implementation/main.py
+++ b/onlinejudge/_implementation/main.py
@@ -105,7 +105,7 @@ supported services:
     subparser.add_argument('--no-guess-latest', action='store_false', dest='guess_cxx_latest')
     subparser.add_argument('--guess-cxx-latest', action='store_true', help='use the lasest version for C++ (default)')
     subparser.add_argument('--guess-cxx-compiler', choices=('gcc', 'clang', 'all'), default='gcc', help='use the specified C++ compiler if both of GCC and Clang are available (default: gcc)')
-    subparser.add_argument('--guess-python-version', choices=('2', '3', 'auto', 'all'), default='auto', help='shebang or modelines are used by default. write something like "#!/usr/bin/env python3". (default: auto)')
+    subparser.add_argument('--guess-python-version', choices=('2', '3', 'auto', 'all'), default='auto', help='default: auto')
     subparser.add_argument('--guess-python-interpreter', choices=('cpython', 'pypy', 'all'), default='cpython', help='use the specified Python interpreter if both of CPython and PyPy are available (default: cpython)')
     subparser.add_argument('--format-dos2unix', action='store_true', help='replace CRLF with LF for given file')
     subparser.add_argument('--format-rstrip', action='store_true', help='remove trailing newlines from given file')


### PR DESCRIPTION
fix #690 

Python コードの提出の際にあった以下の問題を解決します

1. もはや Python 2 は使われてないのに Python 3 の指定が要求される
2.  PyPy を指定するオプションがバグってて機能してない