### PR TITLE
入出力の検出

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -650,16 +650,14 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
         for pre in soup.find(id='task-statement').find_all('pre'):
             log.debug('pre tag: %s', str(pre))
 
-            # the standard format: #task-statement h3+pre
-            # used by AtCoder's JavaScript, sometimes used with .prettyprint
-            # example: https://atcoder.jp/contests/abc114/tasks/abc114_d
-            # NOTE: The AtCoder's JavaScript (at https://atcoder.jp/public/js/contest.js?v=201911110917 version) supports:
-            #     -   "#task-statement h3+pre" format for Copy buttons of <h3> and <pre> tags
-            #     -   "pre.prettyprint" format for Copy buttons of <pre> tags
-            h3 = get_header(tag=pre.find_previous_sibling('h3'))
-            if h3:
-                yield (pre, h3)
-                continue
+            # a very old format: #task-statement p+pre.literal-block
+            # entirely unsupported by AtCoder's JavaScript
+            # example: https://atcoder.jp/contests/utpc2011/tasks/utpc2011_1
+            if 'literal-block' in pre.attrs.get('class', []):
+                p = get_header(tag=pre.find_previous_sibling('p'))
+                if p:
+                    yield (pre, p)
+                    continue
 
             # a old format: #task-statement h3+section>pre:first-child
             # partially supported by AtCoder's JavaScript
@@ -672,14 +670,16 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
                     yield (pre, h3)
                     continue
 
-            # a very old format: #task-statement p+pre.literal-block
-            # entirely unsupported by AtCoder's JavaScript
-            # example: https://atcoder.jp/contests/utpc2011/tasks/utpc2011_1
-            if 'literal-block' in pre.attrs.get('class', []):
-                p = get_header(tag=pre.find_previous_sibling('p'))
-                if p:
-                    yield (pre, p)
-                    continue
+            # the standard format: #task-statement h3+pre
+            # used by AtCoder's JavaScript, sometimes used with .prettyprint
+            # example: https://atcoder.jp/contests/abc114/tasks/abc114_d
+            # NOTE: The AtCoder's JavaScript (at https://atcoder.jp/public/js/contest.js?v=201911110917 version) supports:
+            #     -   "#task-statement h3+pre" format for Copy buttons of <h3> and <pre> tags
+            #     -   "pre.prettyprint" format for Copy buttons of <pre> tags
+            h3 = get_header(tag=pre.find_previous_sibling('h3'))
+            if h3:
+                yield (pre, h3)
+                continue
 
     @classmethod
     def _parse_sample_cases(cls, soup: bs4.BeautifulSoup) -> List[onlinejudge.type.TestCase]:

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -654,18 +654,18 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
             log.debug('pre tag: %s', str(pre))
 
             # a very old format: #task-statement p+pre.literal-block
-            # between <p> and <pre class="literal-block">, text and <br> are ignored
+            # between <p> and <pre class="literal-block">, ignore text and <br>
             # entirely unsupported by AtCoder's JavaScript
             # NOTE: h3+p+pre.literal-block can be regarded as the standard format, so FIRSTLY check a very old format.
             # example: https://atcoder.jp/contests/utpc2011/tasks/utpc2011_1
             if 'literal-block' in pre.attrs.get('class', []):
-                p = get_header(tag=pre.find_previous_sibling(), expected_tag_name='p', ignore_tag_names=('br', ))
+                p = get_header(tag=pre.find_previous_sibling(), expected_tag_name='p', ignore_tag_names=('br',))
                 if p:
                     yield (pre, p)
                     continue
 
             # a old format: #task-statement h3+section>pre:first-child
-            # between <h3> and <section>, text, <br> and <p> are ignored
+            # between <h3> and <section>, ignore text, <br> and <p>
             # partially supported by AtCoder's JavaScript
             # NOTE: The relaxed format "#task-statement h3+section>pre" may cause false-positive. e.g. https://atcoder.jp/contests/abc003/tasks/abc003_4
             # NOTE: The format "h3+section>pre.prettyprint" sometimes cause false-negative. e.g. https://atcoder.jp/contests/tdpc/tasks/tdpc_fibonacci
@@ -677,7 +677,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
                     continue
 
             # the standard format: #task-statement h3+pre
-            # between <h3> and <pre>, text, <p> and <br> are ignored
+            # between <h3> and <pre>, ignore text, <br> and <p>
             # used by AtCoder's JavaScript, sometimes used with .prettyprint
             # example: https://atcoder.jp/contests/abc114/tasks/abc114_d
             # NOTE: The AtCoder's JavaScript (at https://atcoder.jp/public/js/contest.js?v=201911110917 version) supports:

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -643,7 +643,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
         expected_strings = ('入力例', '出力例', 'Sample Input', 'Sample Output')
 
         def get_header(tag, expected_tag_name, ignore_tag_names):
-            assert not (expected_tag_name in ignore_tag_names)
+            assert expected_tag_name not in ignore_tag_names
             while tag and tag.name in ignore_tag_names:
                 tag = tag.find_previous_sibling()
             if tag and tag.name == expected_tag_name and tag.string and any(s in tag.string for s in expected_strings):
@@ -654,18 +654,18 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
             log.debug('pre tag: %s', str(pre))
 
             # a very old format: #task-statement p+pre.literal-block
-            # p+(br)+pre.literal-block, p+(br)+(br)+pre.literal-block, ... is also accepted
+            # between <p> and <pre class="literal-block">, text and <br> are ignored
             # entirely unsupported by AtCoder's JavaScript
             # NOTE: h3+p+pre.literal-block can be regarded as the standard format, so FIRSTLY check a very old format.
             # example: https://atcoder.jp/contests/utpc2011/tasks/utpc2011_1
             if 'literal-block' in pre.attrs.get('class', []):
-                p = get_header(tag=pre.find_previous_sibling(), expected_tag_name='p', ignore_tag_names=('br'))
+                p = get_header(tag=pre.find_previous_sibling(), expected_tag_name='p', ignore_tag_names=('br', ))
                 if p:
                     yield (pre, p)
                     continue
 
             # a old format: #task-statement h3+section>pre:first-child
-            # h3+(br,p)+section>pre:first-child, h3+(br,p)+(br,p)+section>pre:first-child, ... is also accepted
+            # between <h3> and <section>, text, <br> and <p> are ignored
             # partially supported by AtCoder's JavaScript
             # NOTE: The relaxed format "#task-statement h3+section>pre" may cause false-positive. e.g. https://atcoder.jp/contests/abc003/tasks/abc003_4
             # NOTE: The format "h3+section>pre.prettyprint" sometimes cause false-negative. e.g. https://atcoder.jp/contests/tdpc/tasks/tdpc_fibonacci
@@ -677,7 +677,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
                     continue
 
             # the standard format: #task-statement h3+pre
-            # h3+(br,p)+pre, h3+(br,p)+(br,p)+pre, ... is also accepted
+            # between <h3> and <pre>, text, <p> and <br> are ignored
             # used by AtCoder's JavaScript, sometimes used with .prettyprint
             # example: https://atcoder.jp/contests/abc114/tasks/abc114_d
             # NOTE: The AtCoder's JavaScript (at https://atcoder.jp/public/js/contest.js?v=201911110917 version) supports:

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -645,7 +645,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
         def get_header(tag, expected_tag_name, ignore_tag_names):
             assert not (expected_tag_name in ignore_tag_names)
             while tag and tag.name in ignore_tag_names:
-                tag = tag.previous_sibling
+                tag = tag.find_previous_sibling()
             if tag and tag.name == expected_tag_name and tag.string and any(s in tag.string for s in expected_strings):
                 return tag
             return None
@@ -658,7 +658,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
             # NOTE: h3+p+pre.literal-block can be regarded as the standard format, so firstly check a very old format.
             # example: https://atcoder.jp/contests/utpc2011/tasks/utpc2011_1
             if 'literal-block' in pre.attrs.get('class', []):
-                p = get_header(tag=pre.previous_sibling, expected_tag_name='p', ignore_tag_names=('br'))
+                p = get_header(tag=pre.find_previous_sibling(), expected_tag_name='p', ignore_tag_names=('br'))
                 if p:
                     yield (pre, p)
                     continue
@@ -669,7 +669,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
             # NOTE: The format "h3+section>pre.prettyprint" sometimes cause false-negative. e.g. https://atcoder.jp/contests/tdpc/tasks/tdpc_fibonacci
             # example: https://atcoder.jp/contests/abc003/tasks/abc003_4
             if pre.find_previous_sibling() is None and pre.parent.name == 'section':
-                h3 = get_header(tag=pre.parent.previous_sibling, expected_tag_name='h3', ignore_tag_names=('br', 'p'))
+                h3 = get_header(tag=pre.parent.find_previous_sibling(), expected_tag_name='h3', ignore_tag_names=('br', 'p'))
                 if h3:
                     yield (pre, h3)
                     continue
@@ -680,7 +680,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
             # NOTE: The AtCoder's JavaScript (at https://atcoder.jp/public/js/contest.js?v=201911110917 version) supports:
             #     -   "#task-statement h3+pre" format for Copy buttons of <h3> and <pre> tags
             #     -   "pre.prettyprint" format for Copy buttons of <pre> tags
-            h3 = get_header(tag=pre.previous_sibling, expected_tag_name='h3', ignore_tag_names=('br', 'p'))
+            h3 = get_header(tag=pre.find_previous_sibling(), expected_tag_name='h3', ignore_tag_names=('br', 'p'))
             if h3:
                 yield (pre, h3)
                 continue

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -654,8 +654,9 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
             log.debug('pre tag: %s', str(pre))
 
             # a very old format: #task-statement p+pre.literal-block
+            # p+(br)+pre.literal-block, p+(br)+(br)+pre.literal-block, ... is also accepted
             # entirely unsupported by AtCoder's JavaScript
-            # NOTE: h3+p+pre.literal-block can be regarded as the standard format, so firstly check a very old format.
+            # NOTE: h3+p+pre.literal-block can be regarded as the standard format, so FIRSTLY check a very old format.
             # example: https://atcoder.jp/contests/utpc2011/tasks/utpc2011_1
             if 'literal-block' in pre.attrs.get('class', []):
                 p = get_header(tag=pre.find_previous_sibling(), expected_tag_name='p', ignore_tag_names=('br'))
@@ -664,6 +665,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
                     continue
 
             # a old format: #task-statement h3+section>pre:first-child
+            # h3+(br,p)+section>pre:first-child, h3+(br,p)+(br,p)+section>pre:first-child, ... is also accepted
             # partially supported by AtCoder's JavaScript
             # NOTE: The relaxed format "#task-statement h3+section>pre" may cause false-positive. e.g. https://atcoder.jp/contests/abc003/tasks/abc003_4
             # NOTE: The format "h3+section>pre.prettyprint" sometimes cause false-negative. e.g. https://atcoder.jp/contests/tdpc/tasks/tdpc_fibonacci
@@ -675,6 +677,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
                     continue
 
             # the standard format: #task-statement h3+pre
+            # h3+(br,p)+pre, h3+(br,p)+(br,p)+pre, ... is also accepted
             # used by AtCoder's JavaScript, sometimes used with .prettyprint
             # example: https://atcoder.jp/contests/abc114/tasks/abc114_d
             # NOTE: The AtCoder's JavaScript (at https://atcoder.jp/public/js/contest.js?v=201911110917 version) supports:

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -642,8 +642,8 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
     def _find_sample_tags(cls, soup: bs4.BeautifulSoup) -> Iterator[Tuple[bs4.Tag, bs4.Tag]]:
         expected_strings = ('入力例', '出力例', 'Sample Input', 'Sample Output')
 
-        def get_header(tag, expected_tag_name):
-            if tag and tag.name == expected_tag_name and tag.string and any(s in tag.string for s in expected_strings):
+        def get_header(tag):
+            if tag and tag.string and any(s in tag.string for s in expected_strings):
                 return tag
             return None
 
@@ -656,7 +656,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
             # NOTE: The AtCoder's JavaScript (at https://atcoder.jp/public/js/contest.js?v=201911110917 version) supports:
             #     -   "#task-statement h3+pre" format for Copy buttons of <h3> and <pre> tags
             #     -   "pre.prettyprint" format for Copy buttons of <pre> tags
-            h3 = get_header(tag=pre.find_previous_sibling(), expected_tag_name='h3')
+            h3 = get_header(tag=pre.find_previous_sibling('h3'))
             if h3:
                 yield (pre, h3)
                 continue
@@ -667,7 +667,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
             # NOTE: The format "h3+section>pre.prettyprint" sometimes cause false-negative. e.g. https://atcoder.jp/contests/tdpc/tasks/tdpc_fibonacci
             # example: https://atcoder.jp/contests/abc003/tasks/abc003_4
             if pre.find_previous_sibling() is None and pre.parent.name == 'section':
-                h3 = get_header(tag=pre.parent.find_previous_sibling(), expected_tag_name='h3')
+                h3 = get_header(tag=pre.parent.find_previous_sibling('h3'))
                 if h3:
                     yield (pre, h3)
                     continue
@@ -676,7 +676,7 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
             # entirely unsupported by AtCoder's JavaScript
             # example: https://atcoder.jp/contests/utpc2011/tasks/utpc2011_1
             if 'literal-block' in pre.attrs.get('class', []):
-                p = get_header(tag=pre.find_previous_sibling(), expected_tag_name='p')
+                p = get_header(tag=pre.find_previous_sibling('p'))
                 if p:
                     yield (pre, p)
                     continue

--- a/tests/service_atcoder.py
+++ b/tests/service_atcoder.py
@@ -495,6 +495,11 @@ class AtCoderProblemDataTest(unittest.TestCase):
             TestCase(name='sample-6', input_name='Sample Input 6', input_data=b'2\n1 2\n', output_name='Sample Output 6', output_data=b'1.0\n1.0\n'),
         ])
 
+    def test_download_sample_cases_ttpc2015_inserted_p_tag(self):
+        self.assertEqual(AtCoderProblem.from_url('https://atcoder.jp/contests/ttpc2015/tasks/ttpc2015_i').download_sample_cases(), [
+            TestCase(name='sample-1', input_name='Sample Input 1', input_data=b'5\n4 2 3 1 5\n', output_name='Sample Output 1', output_data=b'3\n2 4\n1 2\n2 4\n'),
+        ])
+
 
 class AtCoderProblemGetInputFormatTest(unittest.TestCase):
     def test_normal(self):

--- a/tests/service_atcoder.py
+++ b/tests/service_atcoder.py
@@ -497,7 +497,7 @@ class AtCoderProblemDataTest(unittest.TestCase):
 
     def test_download_sample_cases_ttpc2015_inserted_p_tag(self):
         self.assertEqual(AtCoderProblem.from_url('https://atcoder.jp/contests/ttpc2015/tasks/ttpc2015_i').download_sample_cases(), [
-            TestCase(name='sample-1', input_name='Sample Input 1', input_data=b'5\n4 2 3 1 5\n', output_name='Sample Output 1', output_data=b'3\n2 4\n1 2\n2 4\n'),
+            TestCase(name='sample-1', input_name='入力例1', input_data=b'5\n4 2 3 1 5\n', output_name='出力例1', output_data=b'3\n2 4\n1 2\n2 4\n'),
         ])
 
 


### PR DESCRIPTION
https://atcoder.jp/contests/ttpc2015/tasks/ttpc2015_i
この問題のサンプルのダウンロードに失敗します。preとh3の間にpが存在するのが問題なので、find_previous_siblingにexpected_tag_nameを入れればよいと思います。get_headerでのチェックも不要となります。