### PR TITLE
[service: codeforces] ignore NavigableString from tag.children while …

### DIFF
--- a/onlinejudge/service/codeforces.py
+++ b/onlinejudge/service/codeforces.py
@@ -319,8 +319,10 @@ class CodeforcesProblem(onlinejudge.type.Problem):
         samples = onlinejudge._implementation.testcase_zipper.SampleZipper()
         for tag in soup.find_all('div', class_=re.compile('^(in|out)put$')):  # Codeforces writes very nice HTML :)
             log.debug('tag: %s', str(tag))
-            assert len(list(tag.children)) == 2  # if not 2, next line throws ValueError.
-            title, pre = list(tag.children)
+            non_empty_children = [child for child in tag.children if type(child) is not bs4.element.NavigableString]
+            log.debug("tags after removing bs4.element.NavigableString: %s", non_empty_children)
+            assert len(non_empty_children) == 2  # if not 2, next line throws ValueError.
+            title, pre = list(non_empty_children)
             assert 'title' in title.attrs['class']
             assert pre.name == 'pre'
             s = utils.parse_content(pre)


### PR DESCRIPTION
…downloading sample cases

Before this commit, downloading sample cases from codeforces was failing, probably
due to some format changes on codeforces website.

Following test cases were failing before this commit
```
FAILED tests/command_download_codeforces.py::DownloadCodeforcesTest::test_call_download_codeforces_contest_1080_a - subprocess.CalledProcessError: Command '['/home/nilesh/.python/py3/bin/...
FAILED tests/command_download_codeforces.py::DownloadCodeforcesTest::test_call_download_codeforces_contest_538_h - subprocess.CalledProcessError: Command '['/home/nilesh/.python/py3/bin/p...
FAILED tests/command_download_codeforces.py::DownloadCodeforcesTest::test_call_download_codeforces_gym_101020_a - subprocess.CalledProcessError: Command '['/home/nilesh/.python/py3/bin/py...
FAILED tests/command_download_codeforces.py::DownloadCodeforcesTest::test_call_download_codeforces_problemset_700_b - subprocess.CalledProcessError: Command '['/home/nilesh/.python/py3/bi...
```

Rest of the tests are as they were before.