### PR TITLE
Support new URL of AOJ

### DIFF
--- a/onlinejudge/service/aoj.py
+++ b/onlinejudge/service/aoj.py
@@ -145,6 +145,7 @@ class AOJProblem(onlinejudge.type.Problem):
         # example: https://onlinejudge.u-aizu.ac.jp/problems/CGL_3_B
         m = re.match(r'^/problems/(\w+)$', utils.normpath(result.path))
         if result.scheme in ('', 'http', 'https') \
+                and result.netloc == 'onlinejudge.u-aizu.ac.jp' \
                 and m:
             n = m.group(1)
             return cls(problem_id=n)

--- a/onlinejudge/service/aoj.py
+++ b/onlinejudge/service/aoj.py
@@ -141,6 +141,14 @@ class AOJProblem(onlinejudge.type.Problem):
             n = m.group(5)
             return cls(problem_id=n)
 
+        # example: https://onlinejudge.u-aizu.ac.jp/problems/0423
+        # example: https://onlinejudge.u-aizu.ac.jp/problems/CGL_3_B
+        m = re.match(r'^/problems/(\w+)$', utils.normpath(result.path))
+        if result.scheme in ('', 'http', 'https') \
+                and m:
+            n = m.group(1)
+            return cls(problem_id=n)
+
         return None
 
     def get_service(self) -> AOJService:

--- a/tests/command_download_aoj.py
+++ b/tests/command_download_aoj.py
@@ -63,6 +63,18 @@ class DownloadAOJTest(unittest.TestCase):
             'judge_data.out': '8d2f7846dc2fc10ef37dcb548635c788',
         }, is_system=True)
 
+    def test_call_download_aoj_system_problems_ITP1_1_B(self):
+        self.snippet_call_download('https://onlinejudge.u-aizu.ac.jp/problems/ITP1_1_B', {
+            'test1.in': 'b026324c6904b2a9cb4b88d6d61c81d1',
+            'test1.out': 'b026324c6904b2a9cb4b88d6d61c81d1',
+            'test2.in': '6d7fce9fee471194aa8b5b6e47267f03',
+            'test2.out': '66a7c1d5cb75ef2542524d888fd32f4a',
+            'test3.in': '9caff0735bc6e80121cedcb98ca51821',
+            'test3.out': 'fef5f767008b27f5c3801382264f46ef',
+            'test4.in': '919d117956d3135c4c683ff021352f5c',
+            'test4.out': 'b39ffd5aa5029d696193c8362dcb1d19',
+        }, is_system=True)
+
 
 class DownloadAOJArenaTest(unittest.TestCase):
     def snippet_call_download(self, *args, **kwargs):


### PR DESCRIPTION
#737 

https://onlinejudge.u-aizu.ac.jp/problems/{problem_id}
という形のURLを認識できるように変更しました。

あまり慣れていないのですが、プルリクこんな感じで大丈夫でしょうか…？