### PR TITLE
Skip language option tags without `value` at AtCoder

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -725,7 +725,9 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
         select = form.find('div', id='select-lang').find('select', attrs={'name': 'data.LanguageId'})  # NOTE: AtCoder can vary languages depending on tasks, even in one contest. here, ignores this fact.
         languages = []  # type: List[Language]
         for option in select.find_all('option'):
-            languages += [Language(option.attrs['value'], option.string)]
+            # As of May 1st 2020, the first option does not have a value element.
+            if 'value' in option.attrs:
+                languages += [Language(option.attrs['value'], option.string)]
         return languages
 
     @classmethod


### PR DESCRIPTION
# What does this PR change?
This PR fixes a parse error when parsing available languages from AtCoder submit pages.

# Background
When I tried to submit my code to AtCoder, I faced the following error today.

```bash
$ oj -v s https://atcoder.jp/contests/abc055/tasks/abc055_b main.cpp

...

Traceback (most recent call last):
  File "/Users/kazuhiroserizawa/.pyenv/versions/3.8.0/lib/python3.8/site-packages/onlinejudge/_implementation/main.py", line 233, in main
    run_program(namespace, parser=parser)
  File "/Users/kazuhiroserizawa/.pyenv/versions/3.8.0/lib/python3.8/site-packages/onlinejudge/_implementation/main.py", line 212, in run_program
    submit(args)
  File "/Users/kazuhiroserizawa/.pyenv/versions/3.8.0/lib/python3.8/site-packages/onlinejudge/_implementation/command/submit.py", line 56, in submit
    language_dict = {language.id: language.name for language in problem.get_available_languages(session=sess)}  # type: Dict[LanguageId, str]
  File "/Users/kazuhiroserizawa/.pyenv/versions/3.8.0/lib/python3.8/site-packages/onlinejudge/service/atcoder.py", line 869, in get_available_languages
    data = self.download_data(session=session)
  File "/Users/kazuhiroserizawa/.pyenv/versions/3.8.0/lib/python3.8/site-packages/onlinejudge/service/atcoder.py", line 804, in download_data
    return AtCoderProblemDetailedData.from_html(html, problem=self, session=session, response=resp, timestamp=timestamp)
  File "/Users/kazuhiroserizawa/.pyenv/versions/3.8.0/lib/python3.8/site-packages/onlinejudge/service/atcoder.py", line 760, in from_html
    available_languages = cls._parse_available_languages(soup, problem=problem)
  File "/Users/kazuhiroserizawa/.pyenv/versions/3.8.0/lib/python3.8/site-packages/onlinejudge/service/atcoder.py", line 728, in _parse_available_languages
    languages += [Language(option.attrs['value'], option.string)]
KeyError: 'value'

[ERROR] 'value'
```

This error was caused by the modification of the Form of ActCoder's submit pages.
The language select list has an empty option tag for search now.

Because current implementation of oj does not expect option tags without value element, key error occurs when parsing the empty option tag.

![cap](https://user-images.githubusercontent.com/681496/80770068-18709300-8b8a-11ea-9273-aba8ca55126e.png)

This PR modifies the implementation to skip empty option tags.